### PR TITLE
fix: set NODE_ENV=production for GitHub Pages build

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -42,6 +42,7 @@ jobs:
         run: npm run build
         working-directory: src/app/reactjs/reminders-app
         env:
+          NODE_ENV: 'production'
           GITHUB_PAGES: 'true'
 
       - name: Setup Pages


### PR DESCRIPTION
This fixes the deployment build by ensuring NODE_ENV is set to production.

**Issue:** The build was failing because next.config.js only enables `output: 'export'` when both `NODE_ENV=production` and `GITHUB_PAGES=true` are set, but the workflow was only setting GITHUB_PAGES.

**Fix:** Added `NODE_ENV: 'production'` to the build step in deploy-pages.yml.

**Impact:** This allows the static export to work correctly with dynamic routes.