### PR TITLE
fix(blockchain): add npm overrides to resolve security vulnerabilities

### DIFF
--- a/blockchain/package-lock.json
+++ b/blockchain/package-lock.json
@@ -873,28 +873,6 @@
         "hardhat": "^2.28.0"
       }
     },
-    "node_modules/@nomicfoundation/hardhat-ignition": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition/-/hardhat-ignition-3.1.1.tgz",
-      "integrity": "sha512-IAJg4VVzuxm5yVFCQNDIB9uqdOV0sLhNM5R3kt0X8P2vkT6lRbyMVeqG3lJOLw5MJG9yIBVk9Gv+l58rOs2odQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@nomicfoundation/hardhat-errors": "^3.0.10",
-        "@nomicfoundation/hardhat-utils": "^4.0.2",
-        "@nomicfoundation/ignition-core": "^3.1.1",
-        "@nomicfoundation/ignition-ui": "^3.1.1",
-        "chalk": "^5.3.0",
-        "debug": "^4.3.2",
-        "json5": "^2.2.3",
-        "prompts": "^2.4.2"
-      },
-      "peerDependencies": {
-        "@nomicfoundation/hardhat-verify": "^3.0.0",
-        "hardhat": "^3.1.5"
-      }
-    },
     "node_modules/@nomicfoundation/hardhat-ignition-ethers": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition-ethers/-/hardhat-ignition-ethers-3.1.1.tgz",
@@ -911,20 +889,6 @@
         "@nomicfoundation/ignition-core": "^3.0.7",
         "ethers": "^6.14.0",
         "hardhat": "^3.1.5"
-      }
-    },
-    "node_modules/@nomicfoundation/hardhat-ignition/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@nomicfoundation/hardhat-network-helpers": {
@@ -994,58 +958,6 @@
       "peerDependencies": {
         "hardhat": "^2.26.0"
       }
-    },
-    "node_modules/@nomicfoundation/ignition-core": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-core/-/ignition-core-3.1.1.tgz",
-      "integrity": "sha512-GcVYniz1jlEogq61y6yCZm6AZJzASFfmDvYj3+bJRkASs14bfctvQ0gkO2bV3bMoxIijfAEJQlDmFwWjXjj/ow==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/address": "5.6.1",
-        "@nomicfoundation/hardhat-errors": "^3.0.10",
-        "@nomicfoundation/hardhat-utils": "^4.0.2",
-        "@nomicfoundation/solidity-analyzer": "^0.1.1",
-        "cbor2": "^1.9.0",
-        "debug": "^4.3.2",
-        "ethers": "^6.14.0",
-        "immer": "10.0.2",
-        "lodash-es": "4.17.21",
-        "ndjson": "2.0.0"
-      }
-    },
-    "node_modules/@nomicfoundation/ignition-core/node_modules/@ethersproject/address": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-      "integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.1"
-      }
-    },
-    "node_modules/@nomicfoundation/ignition-ui": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-ui/-/ignition-ui-3.1.1.tgz",
-      "integrity": "sha512-j5eSn7bc//vJjFilRJ7EWX+BodGnujNi8USCfa88Lny6rnwClpuhGPW07pAiV80eZ3EpUOPmhPLRDyoL1mqgwA==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/@nomicfoundation/solidity-analyzer": {
       "version": "0.1.2",
@@ -2021,17 +1933,6 @@
       },
       "engines": {
         "node": ">=12.19"
-      }
-    },
-    "node_modules/cbor2": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/cbor2/-/cbor2-1.12.0.tgz",
-      "integrity": "sha512-3Cco8XQhi27DogSp9Ri6LYNZLi/TBY/JVnDe+mj06NkBjW/ZYOtekaEU4wZ4xcRMNrFkDv8KNtOAqHyDfz3lYg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18.7"
       }
     },
     "node_modules/chai": {
@@ -3888,18 +3789,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immer": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.2.tgz",
-      "integrity": "sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/immutable": {
       "version": "4.3.8",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
@@ -4165,28 +4054,6 @@
         "node": ">=7.10.1"
       }
     },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/jsonfile": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
@@ -4236,17 +4103,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -4283,14 +4139,6 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lodash-es": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
-      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -4726,27 +4574,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ndjson": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-2.0.0.tgz",
-      "integrity": "sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "json-stringify-safe": "^5.0.1",
-        "minimist": "^1.2.5",
-        "readable-stream": "^3.6.0",
-        "split2": "^3.0.0",
-        "through2": "^4.0.0"
-      },
-      "bin": {
-        "ndjson": "cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -5134,21 +4961,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/prompts": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "kleur": "^3.0.3",
-        "sisteransi": "^1.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
@@ -5595,13 +5407,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-function-length": {
@@ -5763,14 +5575,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/sisteransi": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -6026,17 +5830,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/split2": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "readable-stream": "^3.0.0"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -6245,17 +6038,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/through2": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "readable-stream": "3"
-      }
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6305,9 +6087,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6709,13 +6491,17 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/blockchain/package.json
+++ b/blockchain/package.json
@@ -36,7 +36,9 @@
     "typescript": "^5.9.3"
   },
   "overrides": {
-    "tmp": "^0.2.4",
+    "tmp": ">=0.2.7",
+    "uuid": ">=9.0.1",
+    "serialize-javascript": ">=7.0.5",
     "cookie": ">=0.7.0",
     "elliptic": ">=6.6.1",
     "@ethersproject/signing-key": {


### PR DESCRIPTION
## Security Fix

Adds npm `overrides` to `blockchain/package.json` to resolve open Dependabot alerts for vulnerable transitive dependencies.

### Changes
| Package | Vulnerable | Fixed | Severity |
|---------|-----------|-------|----------|
| `tmp` | ^0.2.4 | **>=0.2.7** | 🔴 High — Path Traversal |
| `uuid` | 3.x | **>=9.0.1** | 🟠 Medium — Buffer bounds check |
| `serialize-javascript` | old | **>=7.0.5** | 🟠 Medium — CPU Exhaustion DoS |

### Verified
- ✅ `npm install --package-lock-only --legacy-peer-deps` succeeds