### PR TITLE
fix: upgrade AutoMapper 12→15.1.1 and Nethereum.Web3 5→6.1.0

### DIFF
--- a/src/server/api/dotnet/Reminders.Api/Layers/Application/Extensions/ApplicationConfiguration.cs
+++ b/src/server/api/dotnet/Reminders.Api/Layers/Application/Extensions/ApplicationConfiguration.cs
@@ -12,7 +12,7 @@ public static class ApplicationConfiguration
         SupportedDatabases supportedDatabases = SupportedDatabases.SqlServer)
     {
         services
-            .AddSingleton(AutoMapperConfiguration.CreateMapper());
+            .AddSingleton<IMapper>(sp => AutoMapperConfiguration.CreateMapper(sp.GetService<ILoggerFactory>()));
 
         if (connectionString is not null)
         {

--- a/src/server/api/dotnet/Reminders.Api/Layers/Application/Mapper/Extensions/AutoMapperConfiguration.cs
+++ b/src/server/api/dotnet/Reminders.Api/Layers/Application/Mapper/Extensions/AutoMapperConfiguration.cs
@@ -1,10 +1,13 @@
-﻿namespace Reminders.Application.Mapper.Extensions;
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Reminders.Application.Mapper.Extensions;
 
 public static class AutoMapperConfiguration
 {
-    public static IMapper CreateMapper() =>
-        new MapperConfiguration(cfg =>
-        {
-            cfg.AddProfile(new AutoMapperProfile());
-        }).CreateMapper();
+    public static IMapper CreateMapper(ILoggerFactory? loggerFactory = null) =>
+        new MapperConfiguration(
+            (IMapperConfigurationExpression cfg) => cfg.AddProfile(new AutoMapperProfile()),
+            loggerFactory ?? NullLoggerFactory.Instance
+        ).CreateMapper();
 }

--- a/src/server/api/dotnet/Reminders.Api/Reminders.Api.csproj
+++ b/src/server/api/dotnet/Reminders.Api/Reminders.Api.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="12.0.1" />
+    <PackageReference Include="AutoMapper" Version="15.1.1" />
     <PackageReference Include="Dapper" Version="2.1.28" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="FluentValidation" Version="11.9.0" />
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0" />
-    <PackageReference Include="Nethereum.Web3" Version="5.0.0" />
+    <PackageReference Include="Nethereum.Web3" Version="6.1.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Polly" Version="7.2.3" />


### PR DESCRIPTION
## Security Fix

Resolves the dependency conflict that was blocking PR #260 (AutoMapper Dependabot PR).

### Problem
AutoMapper 15.1.1 requires `Microsoft.Extensions.Logging.Abstractions >= 10.0.0`, but the previous `Nethereum.Web3 5.0.0` restricted it to `< 10.0.0` — an incompatible constraint (NU1107).

### Changes
| Package | Before | After | Reason |
|---------|--------|-------|--------|
| `AutoMapper` | 12.0.1 | **15.1.1** | Security: uncontrolled recursion DoS fix |
| `Nethereum.Web3` | 5.0.0 | **6.1.0** | Removes the MEL.Abstractions upper-bound restriction |

### Code changes
- `AutoMapperConfiguration.cs`: AutoMapper 15 now requires `ILoggerFactory` as a second parameter — added with `NullLoggerFactory.Instance` as fallback
- `ApplicationConfiguration.cs`: Changed DI registration to a factory delegate so the real `ILoggerFactory` is injected from the service provider

### Verified
- ✅ `dotnet restore Reminders.sln` — no NU1107 conflict
- ✅ `dotnet build Reminders.sln` — 0 errors

Closes #260