### PR TITLE
ci: enforce conventional commit PR titles

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,41 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-title:
+    name: Validate conventional commit title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            refactor
+            test
+            docs
+            ci
+            chore
+            perf
+            build
+          scopes: |
+            api
+            go
+            cpp
+            react
+            mvc
+            blockchain
+            migrations
+            infra
+            ci
+            deps
+            deps-dev
+          requireScope: false


### PR DESCRIPTION
## Summary
- New workflow validates PR titles against Conventional Commits (types + project scopes)
- Squash merge uses PR title as trunk commit subject, so this enforces clean history

Closes #314

## Test plan
- [ ] Workflow runs on this PR and passes (title is conventional)