### PR TITLE
docs(react): add reminders redesign handoff bundle

### DIFF
--- a/docs/design/reminders-redesign/README.md
+++ b/docs/design/reminders-redesign/README.md
@@ -1,0 +1,73 @@
+# Handoff: Reminders App Redesign
+
+## Overview
+A fresh, full redesign of the Reminders CRUD frontend (currently a Material UI table app in `jumperck/Reminders`, `src/app/reactjs/reminders-app`). It replaces the plain table with a warm, editorial productivity UI: a grouped reminder list (Overdue / Today / Upcoming / Done), search, view filters, week-progress meter, create/edit modal, delete confirmation, empty states, and a dedicated mobile layout.
+
+## About the Design Files
+The files in this bundle are **design references created in HTML** — prototypes showing intended look and behavior, not production code to copy directly. The task is to **recreate these designs in the existing Next.js/React app** (`reminders-app`), using its established patterns (App Router pages, the existing `api/reminders` service layer and `Reminder` type). Drop the MUI table/components in favor of this design; either plain CSS modules/styled JSX or keep MUI only as unstyled primitives.
+
+## Fidelity
+**High-fidelity.** Colors, typography, spacing, and interactions are final. Recreate pixel-perfectly.
+
+## Data model (unchanged)
+`Reminder { id: number; title: string; description: string; limitDate: string (YYYY-MM-DD); isDone: boolean }`
+
+## Screens / Views
+
+### 1. Reminders list (desktop ≥760px)
+- **Layout**: sticky top header + two-column body, max-width 1280px centered, gutters `clamp(20px, 4vw, 48px)`, column gap `clamp(24px, 4vw, 56px)`.
+- **Header** (sticky, canvas bg `#F3F0E9`, bottom border `#E0DACD`): page title "Reminders" (Instrument Serif 30px) + today's date in italic serif 19px `#8C8577`; search pill (surface `#FBFAF7`, border `#E0DACD`, radius 999px, magnifier icon, no focus outline); primary button "New reminder" (ink `#1B1A17` bg, `#F7F5F0` text, pill, hover → `#B4451F`).
+- **Sidebar** (210–260px, sticky): nav items All / Today / Upcoming / Done with counts — active: `#E7E2D6` bg, radius 10, 5px accent dot; inactive: transparent, hover `#EBE7DC`. Below a divider: "THIS WEEK" label (11.5px uppercase `#8C8577`), % stat (Instrument Serif 40px), 5px progress bar (track `#E0DACD`, fill `#B4451F`), caption 13.5px `#6E6759` (shows overdue count if any).
+- **List**: sections per group (Overdue, Today, Upcoming, Done — ordered, empty groups hidden). Section header: serif 22px title + count + 1px rule filling the row. Cards gap 10.
+- **Reminder card**: surface `#FBFAF7`, border `#E7E2D6` (hover `#CFC7B5`), radius 14, padding 16px 18px, `display:flex; align-items:center; gap:14px`.
+  - Checkbox: 24px circle. Open: `1.6px solid #C6BDA9`, hover green tint `#EDF1EC`. Done: solid `#4C6B4F` with white check.
+  - Title 15.5px/500 (done: `#9A9385` + line-through); description 13.8px `#6E6759` below when present.
+  - Date pill: overdue = `#B4451F` on `#F6E4DC` ("3 days late" / "Yesterday"); otherwise `#6E6759` on `#F0EDE4` ("Today", "Tomorrow", "Aug 4").
+  - Edit: 34px icon button, hover `#EBE7DC`.
+- **Empty state**: dashed border `#D5CEBE` panel, radius 18, serif 27px title + 15px body + primary button; copy varies per view/search (see prototype logic).
+
+### 2. Reminders list (mobile <760px)
+- Sticky header: title row (serif 25px + short date), full-width search pill, horizontally scrolling filter chips (active = ink pill w/ light text; inactive = surface w/ border). 40px min height chips.
+- Progress compresses to a strip under the header: panel bg `#EFEBE1`, serif 22px %, inline bar, caption right-aligned.
+- Same cards, single column.
+- FAB "New" bottom-right: ink pill, 52px min height, shadow `0 10px 26px rgba(27,26,23,0.28)`.
+- In the prototype, mobile is showcased inside an iPhone frame (`ios-frame.jsx`) — the frame is presentation only, not part of the app.
+
+### 3. Create / Edit modal
+- Centered overlay, scrim `rgba(27,26,23,0.34)`, click-outside closes; card max-width 560px, `#FBFAF7`, radius 20, padding 28px, entrance `sheetIn` 0.22s translateY(16px)+fade.
+- Title "New reminder" / "Edit reminder" (serif 27px) + "Close" text button.
+- Fields (gap 18): Title (text), Description (textarea, 3 rows), then Limit date (native date input, pointer cursor incl. calendar icon) + Status toggle side by side (flex, wrap). All inputs: `1px solid #DDD7C9`, bg `#F7F5F0`, radius 10, **fixed height 48px** (textarea excepted), focus = 2px `#B4451F` outline. Labels 11.5px uppercase `#8C8577`.
+- Status toggle: button with 20px rounded-square check (green ✓ when done) + "Done" / "Not done yet".
+- Footer: primary "Create reminder"/"Save changes", secondary "Cancel" (border pill), and on edit a right-aligned text-danger "Delete reminder".
+- Save disabled/no-op when title is blank.
+
+### 4. Delete confirmation
+- Smaller centered dialog, max-width 400px, radius 16, scrim `rgba(27,26,23,0.42)`.
+- Serif 24px "Delete this reminder?", body quotes the reminder title, buttons: destructive "Delete" (`#B4451F` bg, hover `#8E3415`) + secondary "Keep it".
+
+## Interactions & Behavior
+- Checkbox toggles `isDone` instantly (optimistic update; card moves group).
+- Card edit icon → edit modal prefilled; "New reminder" / FAB → create modal with limitDate defaulting to tomorrow.
+- Search filters title + description live; view filters: All / Today (due today) / Upcoming (future, not done) / Done.
+- Items sorted ascending by limitDate within groups.
+- Overdue = not done && limitDate < today.
+- Hover states on every clickable; pointer cursor everywhere, incl. date input + its calendar icon.
+- Modals: fadeIn 0.16s scrim, sheetIn 0.22s cubic-bezier(.22,.9,.25,1) card; Esc/scrim-click close is expected in production.
+- Responsive: breakpoint 760px switches shells (sidebar ↔ chips+FAB). In production use a CSS media query or container query rather than the prototype's JS resize listener.
+
+## State Management
+- `items: Reminder[]` (from existing API), `query`, `view` ('All'|'Today'|'Upcoming'|'Done'), `draft` (modal form), `sheet` ('create'|'edit'|null), `confirmId`.
+- Derived: grouped/filtered lists, week progress (% done of items due within 7 days), overdue count.
+- Wire create/update/delete/toggle to the existing REST endpoints; prototype uses local state only.
+
+## Design Tokens
+See `design-system.md` (bundled) — canonical palette, type scale, radii, spacing, and component recipes. Fonts: Google Fonts **Instrument Serif** (display) + **DM Sans** (UI).
+
+## Assets
+No image assets. Icons are tiny inline SVGs (plus, magnifier, pencil, check) — copy paths from the prototypes or use an icon library equivalent. iPhone bezel (`ios-frame.jsx`) is presentation-only.
+
+## Files
+- `Reminders.dc.html` — the full prototype (single source: template markup + logic class). All exact styles are inline here.
+- `Reminders Desktop.dc.html`, `Reminders Tablet.dc.html`, `Reminders Mobile.dc.html` — thin wrappers forcing a layout (mobile adds the iPhone frame).
+- `ios-frame.jsx` — device frame used by the mobile showcase.
+- `design-system.md` — design tokens & component recipes.

--- a/docs/design/reminders-redesign/Reminders Desktop.dc.html
+++ b/docs/design/reminders-redesign/Reminders Desktop.dc.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<dc-import name="Reminders" layout="desktop" hint-size="100%,100%"></dc-import>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1440,&quot;height&quot;:900}}"></script>
+</body>
+</html>

--- a/docs/design/reminders-redesign/Reminders Mobile.dc.html
+++ b/docs/design/reminders-redesign/Reminders Mobile.dc.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<style>
+  html, body { margin: 0; padding: 0; background: #E5E1D7; }
+</style>
+</helmet>
+<div style="min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 48px 24px; background: #E5E1D7;">
+  <div style="transform: translateZ(0); width: 402px; height: 874px;">
+    <x-import component-from-global-scope="IOSDevice" from="./ios-frame.jsx" width="{{ 402 }}" height="{{ 874 }}" hint-size="402px,874px">
+      <dc-import name="Reminders" layout="mobile" safe-area="{{ true }}" hint-size="100%,100%"></dc-import>
+    </x-import>
+  </div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:500,&quot;height&quot;:980}}"></script>
+</body>
+</html>

--- a/docs/design/reminders-redesign/Reminders Tablet.dc.html
+++ b/docs/design/reminders-redesign/Reminders Tablet.dc.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<dc-import name="Reminders" layout="desktop" hint-size="100%,100%"></dc-import>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:834,&quot;height&quot;:1000}}"></script>
+</body>
+</html>

--- a/docs/design/reminders-redesign/Reminders.dc.html
+++ b/docs/design/reminders-redesign/Reminders.dc.html
@@ -1,0 +1,434 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
+<link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,700&display=swap" rel="stylesheet" />
+<style>
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: #F3F0E9; }
+  body { font-family: "DM Sans", system-ui, sans-serif; -webkit-font-smoothing: antialiased; }
+  a { color: #B4451F; text-decoration: none; }
+  a:hover { color: #8E3415; text-decoration: underline; }
+  input, textarea, button { font: inherit; color: inherit; }
+  input:focus, textarea:focus { outline: 2px solid #B4451F; outline-offset: 1px; }
+  ::placeholder { color: #A8A093; }
+  input[type="date"]::-webkit-calendar-picker-indicator { cursor: pointer; }
+  @keyframes sheetIn { from { transform: translateY(16px); opacity: 0 } to { transform: translateY(0); opacity: 1 } }
+  @keyframes fadeIn { from { opacity: 0 } to { opacity: 1 } }
+</style>
+</helmet>
+<div style="min-height: 100vh; background: #F3F0E9; color: #1B1A17; display: flex; flex-direction: column;">
+
+  <sc-if value="{{ isWide }}" hint-placeholder-val="{{ true }}">
+  <header style="display: flex; align-items: center; gap: 20px; flex-wrap: wrap; padding: 22px clamp(24px, 4vw, 48px); border-bottom: 1px solid #E0DACD; background: #F3F0E9; position: sticky; top: 0; z-index: 5;">
+    <div style="display: flex; align-items: baseline; gap: 10px; margin-right: auto;">
+      <span style="font-family: 'Instrument Serif', serif; font-size: 30px; line-height: 1; letter-spacing: -0.01em;">Reminders</span>
+      <span style="font-family: 'Instrument Serif', serif; font-style: italic; font-size: 19px; color: #8C8577;">{{ todayLabel }}</span>
+    </div>
+    <div style="display: flex; align-items: center; gap: 8px; background: #FBFAF7; border: 1px solid #E0DACD; border-radius: 999px; padding: 9px 16px; min-width: 220px; flex: 0 1 300px;">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#8C8577" stroke-width="2.2" style="flex: none;"><circle cx="11" cy="11" r="7"></circle><path d="M20 20l-4.2-4.2"></path></svg>
+      <input type="text" placeholder="Search reminders" value="{{ query }}" onChange="{{ onQuery }}" style-focus="outline: none;" style="border: none; background: transparent; width: 100%; font-size: 14.5px;" />
+    </div>
+    <button type="button" onClick="{{ startCreate }}" style="display: flex; align-items: center; gap: 8px; background: #1B1A17; color: #F7F5F0; border: none; border-radius: 999px; padding: 12px 20px; font-size: 14.5px; font-weight: 500; cursor: pointer; min-height: 44px;" style-hover="background: #B4451F;">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M12 5v14M5 12h14"></path></svg>
+      New reminder
+    </button>
+  </header>
+  </sc-if>
+
+  <sc-if value="{{ isMobile }}">
+  <header style="display: flex; flex-direction: column; gap: 14px; padding: 16px 18px 12px; border-bottom: 1px solid #E0DACD; background: #F3F0E9; position: sticky; top: 0; z-index: 5;">
+    <sc-if value="{{ safeTop }}"><div style="height: 40px;"></div></sc-if>
+    <div style="display: flex; align-items: baseline; gap: 9px;">
+      <span style="font-family: 'Instrument Serif', serif; font-size: 25px; line-height: 1;">Reminders</span>
+      <span style="font-family: 'Instrument Serif', serif; font-style: italic; font-size: 15px; color: #8C8577; margin-left: auto;">{{ shortDateLabel }}</span>
+    </div>
+    <div style="display: flex; align-items: center; gap: 8px; background: #FBFAF7; border: 1px solid #E0DACD; border-radius: 999px; padding: 10px 15px;">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#8C8577" stroke-width="2.2" style="flex: none;"><circle cx="11" cy="11" r="7"></circle><path d="M20 20l-4.2-4.2"></path></svg>
+      <input type="text" placeholder="Search reminders" value="{{ query }}" onChange="{{ onQuery }}" style-focus="outline: none;" style="border: none; background: transparent; width: 100%; font-size: 15px;" />
+    </div>
+    <div style="display: flex; gap: 7px; overflow-x: auto; margin: 0 -18px; padding: 2px 18px 4px; scrollbar-width: none;">
+      <sc-for list="{{ views }}" as="v" hint-placeholder-count="4">
+        <sc-if value="{{ v.active }}" hint-placeholder-val="{{ true }}">
+          <button type="button" onClick="{{ v.select }}" style="display: flex; align-items: center; gap: 7px; flex: none; background: #1B1A17; color: #F7F5F0; border: none; border-radius: 999px; padding: 9px 15px; font-size: 14px; font-weight: 500; cursor: pointer; min-height: 40px; white-space: nowrap;">
+            <span>{{ v.label }}</span>
+            <span style="font-size: 12.5px; opacity: 0.65; font-variant-numeric: tabular-nums;">{{ v.count }}</span>
+          </button>
+        </sc-if>
+        <sc-if value="{{ v.inactive }}">
+          <button type="button" onClick="{{ v.select }}" style="display: flex; align-items: center; gap: 7px; flex: none; background: #FBFAF7; color: #55503f; border: 1px solid #E0DACD; border-radius: 999px; padding: 9px 15px; font-size: 14px; cursor: pointer; min-height: 40px; white-space: nowrap;" style-hover="border-color: #1B1A17; color: #1B1A17;">
+            <span>{{ v.label }}</span>
+            <span style="font-size: 12.5px; color: #8C8577; font-variant-numeric: tabular-nums;">{{ v.count }}</span>
+          </button>
+        </sc-if>
+      </sc-for>
+    </div>
+  </header>
+  <sc-if value="{{ showProgress }}">
+    <div style="display: flex; align-items: center; gap: 12px; padding: 14px 18px; background: #EFEBE1; border-bottom: 1px solid #E0DACD;">
+      <span style="font-family: 'Instrument Serif', serif; font-size: 22px; line-height: 1; flex: none;">{{ progressLabel }}</span>
+      <div style="flex: 1; height: 5px; border-radius: 999px; background: #DFD8C8; overflow: hidden;">
+        <div style="height: 100%; background: #B4451F; border-radius: 999px; width: {{ progressWidth }};"></div>
+      </div>
+      <span style="font-size: 12.5px; color: #6E6759; flex: none; max-width: 44%; text-align: right; line-height: 1.35;">{{ progressCaption }}</span>
+    </div>
+  </sc-if>
+  </sc-if>
+
+  <div style="display: flex; align-items: flex-start; gap: clamp(24px, 4vw, 56px); padding: clamp(18px, 4vw, 44px) clamp(18px, 4vw, 48px) 120px; flex-wrap: wrap; max-width: 1280px; width: 100%; margin: 0 auto;">
+
+    <sc-if value="{{ isWide }}">
+    <aside style="flex: 1 1 210px; max-width: 260px; min-width: 190px; display: flex; flex-direction: column; gap: 28px; position: sticky; top: 112px;">
+      <nav style="display: flex; flex-direction: column; gap: 2px;">
+        <sc-for list="{{ views }}" as="v" hint-placeholder-count="4">
+          <sc-if value="{{ v.active }}" hint-placeholder-val="{{ true }}">
+            <button type="button" onClick="{{ v.select }}" style="display: flex; align-items: center; gap: 10px; width: 100%; text-align: left; background: #E7E2D6; border: none; border-radius: 10px; padding: 11px 14px; font-size: 15px; font-weight: 500; color: #1B1A17; cursor: pointer; min-height: 44px;">
+              <span style="width: 5px; height: 5px; border-radius: 50%; background: #B4451F; flex: none;"></span>
+              <span style="margin-right: auto;">{{ v.label }}</span>
+              <span style="font-size: 13px; color: #6E6759; font-variant-numeric: tabular-nums;">{{ v.count }}</span>
+            </button>
+          </sc-if>
+          <sc-if value="{{ v.inactive }}">
+            <button type="button" onClick="{{ v.select }}" style="display: flex; align-items: center; gap: 10px; width: 100%; text-align: left; background: transparent; border: none; border-radius: 10px; padding: 11px 14px; font-size: 15px; color: #55503f; cursor: pointer; min-height: 44px;" style-hover="background: #EBE7DC; color: #1B1A17;">
+              <span style="width: 5px; height: 5px; border-radius: 50%; background: transparent; flex: none;"></span>
+              <span style="margin-right: auto;">{{ v.label }}</span>
+              <span style="font-size: 13px; color: #8C8577; font-variant-numeric: tabular-nums;">{{ v.count }}</span>
+            </button>
+          </sc-if>
+        </sc-for>
+      </nav>
+
+      <sc-if value="{{ showProgress }}" hint-placeholder-val="{{ true }}">
+        <div style="border-top: 1px solid #E0DACD; padding-top: 24px; display: flex; flex-direction: column; gap: 12px;">
+          <div style="font-size: 11.5px; letter-spacing: 0.1em; text-transform: uppercase; color: #8C8577;">This week</div>
+          <div style="font-family: 'Instrument Serif', serif; font-size: 40px; line-height: 1;">{{ progressLabel }}</div>
+          <div style="height: 5px; border-radius: 999px; background: #E0DACD; overflow: hidden;">
+            <div style="height: 100%; background: #B4451F; border-radius: 999px; width: {{ progressWidth }};"></div>
+          </div>
+          <div style="font-size: 13.5px; color: #6E6759; line-height: 1.5;">{{ progressCaption }}</div>
+        </div>
+      </sc-if>
+    </aside>
+    </sc-if>
+
+    <main style="flex: 999 1 460px; min-width: 300px; display: flex; flex-direction: column; gap: 30px;">
+      <sc-if value="{{ isEmpty }}">
+        <div style="border: 1px dashed #D5CEBE; border-radius: 18px; padding: 64px 32px; text-align: center; display: flex; flex-direction: column; align-items: center; gap: 14px; background: #F8F6F1;">
+          <span style="font-family: 'Instrument Serif', serif; font-size: 27px;">{{ emptyTitle }}</span>
+          <span style="font-size: 15px; color: #6E6759; max-width: 320px; line-height: 1.55;">{{ emptyBody }}</span>
+          <button type="button" onClick="{{ startCreate }}" style="margin-top: 8px; background: #1B1A17; color: #F7F5F0; border: none; border-radius: 999px; padding: 12px 22px; font-size: 14.5px; cursor: pointer; min-height: 44px;" style-hover="background: #B4451F;">Add a reminder</button>
+        </div>
+      </sc-if>
+
+      <sc-for list="{{ groups }}" as="g" hint-placeholder-count="2">
+        <section style="display: flex; flex-direction: column; gap: 10px;">
+          <div style="display: flex; align-items: center; gap: 12px; padding-bottom: 2px;">
+            <h2 style="margin: 0; font-family: 'Instrument Serif', serif; font-size: 22px; font-weight: 400; letter-spacing: -0.01em;">{{ g.label }}</h2>
+            <span style="font-size: 13px; color: #8C8577; font-variant-numeric: tabular-nums;">{{ g.count }}</span>
+            <span style="flex: 1; height: 1px; background: #E0DACD;"></span>
+          </div>
+
+          <sc-for list="{{ g.items }}" as="item" hint-placeholder-count="3">
+            <article style="display: flex; align-items: center; gap: 14px; background: #FBFAF7; border: 1px solid #E7E2D6; border-radius: 14px; padding: 16px 18px;" style-hover="border-color: #CFC7B5;">
+              <sc-if value="{{ item.isDone }}" hint-placeholder-val="{{ true }}">
+                <button type="button" onClick="{{ item.toggle }}" aria-label="Mark not done" style="flex: none; width: 24px; height: 24px; border-radius: 50%; border: none; background: #4C6B4F; color: #FBFAF7; display: flex; align-items: center; justify-content: center; cursor: pointer;">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2"><path d="M5 13l4.5 4.5L19 7"></path></svg>
+                </button>
+              </sc-if>
+              <sc-if value="{{ item.notDone }}">
+                <button type="button" onClick="{{ item.toggle }}" aria-label="Mark done" style="flex: none; width: 24px; height: 24px; border-radius: 50%; border: 1.6px solid #C6BDA9; background: transparent; cursor: pointer;" style-hover="border-color: #4C6B4F; background: #EDF1EC;"></button>
+              </sc-if>
+
+              <div style="display: flex; flex-direction: column; gap: 5px; margin-right: auto; min-width: 0;">
+                <sc-if value="{{ item.isDone }}">
+                  <span style="font-size: 15.5px; font-weight: 500; color: #9A9385; text-decoration: line-through;">{{ item.title }}</span>
+                </sc-if>
+                <sc-if value="{{ item.notDone }}">
+                  <span style="font-size: 15.5px; font-weight: 500; line-height: 1.35;">{{ item.title }}</span>
+                </sc-if>
+                <sc-if value="{{ item.hasDescription }}">
+                  <span style="font-size: 13.8px; color: #6E6759; line-height: 1.5; text-wrap: pretty;">{{ item.description }}</span>
+                </sc-if>
+              </div>
+
+              <div style="display: flex; align-items: center; gap: 6px; flex: none;">
+                <sc-if value="{{ item.isOverdue }}">
+                  <span style="display: flex; align-items: center; gap: 6px; font-size: 12.5px; font-weight: 500; color: #B4451F; background: #F6E4DC; border-radius: 999px; padding: 6px 11px; white-space: nowrap;">{{ item.dateLabel }}</span>
+                </sc-if>
+                <sc-if value="{{ item.isPlain }}">
+                  <span style="font-size: 12.5px; color: #6E6759; background: #F0EDE4; border-radius: 999px; padding: 6px 11px; white-space: nowrap; font-variant-numeric: tabular-nums;">{{ item.dateLabel }}</span>
+                </sc-if>
+                <button type="button" onClick="{{ item.edit }}" aria-label="Edit reminder" style="width: 34px; height: 34px; display: flex; align-items: center; justify-content: center; border: none; background: transparent; border-radius: 9px; color: #8C8577; cursor: pointer;" style-hover="background: #EBE7DC; color: #1B1A17;">
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9"><path d="M4 20h4L19.5 8.5a2.1 2.1 0 0 0-3-3L5 17v3z"></path></svg>
+                </button>
+              </div>
+            </article>
+          </sc-for>
+        </section>
+      </sc-for>
+    </main>
+  </div>
+
+  <sc-if value="{{ isMobile }}">
+    <button type="button" onClick="{{ startCreate }}" aria-label="New reminder" style="position: fixed; right: 18px; bottom: 22px; z-index: 20; display: flex; align-items: center; gap: 9px; background: #1B1A17; color: #F7F5F0; border: none; border-radius: 999px; padding: 15px 22px; font-size: 15px; font-weight: 500; cursor: pointer; min-height: 52px; box-shadow: 0 10px 26px rgba(27,26,23,0.28);" style-active="background: #B4451F;">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M12 5v14M5 12h14"></path></svg>
+      New
+    </button>
+  </sc-if>
+
+  <sc-if value="{{ sheetOpen }}">
+    <div style="position: fixed; inset: 0; background: rgba(27,26,23,0.34); z-index: 40; display: flex; align-items: center; justify-content: center; padding: 24px; animation: fadeIn 0.16s ease;" onClick="{{ closeSheet }}">
+      <div onClick="{{ stop }}" style="width: 100%; max-width: 560px; background: #FBFAF7; border-radius: 20px; padding: 28px clamp(20px, 4vw, 34px) 26px; box-shadow: 0 18px 50px rgba(27,26,23,0.22); animation: sheetIn 0.22s cubic-bezier(.22,.9,.25,1); max-height: 92vh; overflow: auto;">
+        <div style="display: flex; align-items: baseline; gap: 12px; margin-bottom: 22px;">
+          <span style="font-family: 'Instrument Serif', serif; font-size: 27px;">{{ sheetTitle }}</span>
+          <button type="button" onClick="{{ closeSheet }}" style="margin-left: auto; background: transparent; border: none; color: #8C8577; font-size: 14px; cursor: pointer; padding: 8px;" style-hover="color: #1B1A17;">Close</button>
+        </div>
+
+        <div style="display: flex; flex-direction: column; gap: 18px;">
+          <label style="display: flex; flex-direction: column; gap: 7px;">
+            <span style="font-size: 11.5px; letter-spacing: 0.09em; text-transform: uppercase; color: #8C8577;">Title</span>
+            <input type="text" value="{{ draftTitle }}" onChange="{{ onDraftTitle }}" placeholder="Call the notary" style="border: 1px solid #DDD7C9; background: #F7F5F0; border-radius: 10px; padding: 13px 14px; font-size: 15.5px; min-height: 46px;" />
+          </label>
+          <label style="display: flex; flex-direction: column; gap: 7px;">
+            <span style="font-size: 11.5px; letter-spacing: 0.09em; text-transform: uppercase; color: #8C8577;">Description</span>
+            <textarea rows="3" value="{{ draftDescription }}" onChange="{{ onDraftDescription }}" placeholder="Optional detail" style="border: 1px solid #DDD7C9; background: #F7F5F0; border-radius: 10px; padding: 13px 14px; font-size: 15px; line-height: 1.5; resize: vertical;"></textarea>
+          </label>
+          <div style="display: flex; gap: 16px; flex-wrap: wrap;">
+            <label style="display: flex; flex-direction: column; gap: 7px; flex: 1 1 190px;">
+              <span style="font-size: 11.5px; letter-spacing: 0.09em; text-transform: uppercase; color: #8C8577;">Limit date</span>
+              <input type="date" value="{{ draftDate }}" onChange="{{ onDraftDate }}" style="border: 1px solid #DDD7C9; background: #F7F5F0; border-radius: 10px; padding: 0 14px; font-size: 15px; height: 48px; cursor: pointer;" />
+            </label>
+            <div style="display: flex; flex-direction: column; gap: 7px; flex: 1 1 190px;">
+              <span style="font-size: 11.5px; letter-spacing: 0.09em; text-transform: uppercase; color: #8C8577;">Status</span>
+              <button type="button" onClick="{{ toggleDraftDone }}" style="display: flex; align-items: center; gap: 10px; border: 1px solid #DDD7C9; background: #F7F5F0; border-radius: 10px; padding: 0 14px; font-size: 15px; cursor: pointer; height: 48px; text-align: left;" style-hover="border-color: #C6BDA9;">
+                <span style="width: 20px; height: 20px; border-radius: 6px; border: 1.6px solid #C6BDA9; background: #FBFAF7; display: flex; align-items: center; justify-content: center; flex: none; color: #4C6B4F;">{{ draftCheck }}</span>
+                <span>{{ draftStatusLabel }}</span>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div style="display: flex; align-items: center; gap: 10px; margin-top: 26px; flex-wrap: wrap;">
+          <button type="button" onClick="{{ saveDraft }}" style="background: #1B1A17; color: #F7F5F0; border: none; border-radius: 999px; padding: 13px 26px; font-size: 15px; font-weight: 500; cursor: pointer; min-height: 46px;" style-hover="background: #B4451F;">{{ saveLabel }}</button>
+          <button type="button" onClick="{{ closeSheet }}" style="background: transparent; border: 1px solid #DDD7C9; border-radius: 999px; padding: 13px 22px; font-size: 15px; cursor: pointer; min-height: 46px;" style-hover="border-color: #1B1A17;">Cancel</button>
+          <sc-if value="{{ isEditing }}">
+            <button type="button" onClick="{{ askDelete }}" style="margin-left: auto; background: transparent; border: none; color: #B4451F; font-size: 14.5px; cursor: pointer; padding: 12px; min-height: 46px;" style-hover="text-decoration: underline;">Delete reminder</button>
+          </sc-if>
+        </div>
+      </div>
+    </div>
+  </sc-if>
+
+  <sc-if value="{{ confirmOpen }}">
+    <div style="position: fixed; inset: 0; background: rgba(27,26,23,0.42); z-index: 60; display: flex; align-items: center; justify-content: center; padding: 24px; animation: fadeIn 0.14s ease;" onClick="{{ cancelDelete }}">
+      <div onClick="{{ stop }}" style="width: 100%; max-width: 400px; background: #FBFAF7; border-radius: 16px; padding: 28px; box-shadow: 0 20px 50px rgba(27,26,23,0.24); display: flex; flex-direction: column; gap: 12px;">
+        <span style="font-family: 'Instrument Serif', serif; font-size: 24px;">Delete this reminder?</span>
+        <span style="font-size: 14.5px; color: #6E6759; line-height: 1.55;">{{ confirmBody }}</span>
+        <div style="display: flex; gap: 10px; margin-top: 12px;">
+          <button type="button" onClick="{{ confirmDelete }}" style="background: #B4451F; color: #FBFAF7; border: none; border-radius: 999px; padding: 12px 22px; font-size: 14.5px; font-weight: 500; cursor: pointer; min-height: 44px;" style-hover="background: #8E3415;">Delete</button>
+          <button type="button" onClick="{{ cancelDelete }}" style="background: transparent; border: 1px solid #DDD7C9; border-radius: 999px; padding: 12px 20px; font-size: 14.5px; cursor: pointer; min-height: 44px;" style-hover="border-color: #1B1A17;">Keep it</button>
+        </div>
+      </div>
+    </div>
+  </sc-if>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;layout&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;auto&quot;,&quot;mobile&quot;,&quot;desktop&quot;],&quot;default&quot;:&quot;auto&quot;,&quot;tsType&quot;:&quot;'auto' | 'mobile' | 'desktop'&quot;,&quot;section&quot;:&quot;Layout&quot;},&quot;safeArea&quot;:{&quot;editor&quot;:null,&quot;default&quot;:false,&quot;tsType&quot;:&quot;boolean&quot;},&quot;groupBy&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;date&quot;,&quot;status&quot;,&quot;none&quot;],&quot;default&quot;:&quot;date&quot;,&quot;tsType&quot;:&quot;'date' | 'status' | 'none'&quot;,&quot;section&quot;:&quot;Behavior&quot;},&quot;showProgress&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Behavior&quot;},&quot;showDescriptions&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Behavior&quot;}}">
+const TODAY = new Date(2026, 6, 26);
+
+function iso(d) { return d.toISOString().slice(0, 10); }
+function shift(days) { const d = new Date(TODAY); d.setDate(d.getDate() + days); return iso(d); }
+
+class Component extends DCLogic {
+  state = {
+    width: typeof window === "undefined" ? 1280 : window.innerWidth,
+    query: "",
+    view: "All",
+    sheet: null,
+    confirmId: null,
+    draft: null,
+    nextId: 9,
+    items: [
+      { id: 1, title: "Send signed lease addendum", description: "Scan page 3 with the initials before sending to the agent.", limitDate: shift(-2), isDone: false },
+      { id: 2, title: "Renew car insurance", description: "", limitDate: shift(-6), isDone: false },
+      { id: 3, title: "Book dentist for Mara", description: "Preferably a Thursday afternoon.", limitDate: shift(0), isDone: false },
+      { id: 4, title: "Pay quarterly VAT", description: "Reference number is in the accounting folder.", limitDate: shift(0), isDone: false },
+      { id: 5, title: "Order espresso beans", description: "", limitDate: shift(3), isDone: false },
+      { id: 6, title: "Draft Q3 hiring plan", description: "Two engineers, one designer — share with Nadia first.", limitDate: shift(9), isDone: false },
+      { id: 7, title: "Move standing desk order", description: "", limitDate: shift(21), isDone: false },
+      { id: 8, title: "Cancel gym trial", description: "", limitDate: shift(-1), isDone: true }
+    ]
+  };
+
+  componentDidMount() {
+    this.onResize = () => this.setState({ width: window.innerWidth });
+    window.addEventListener("resize", this.onResize);
+    this.onResize();
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("resize", this.onResize);
+  }
+
+  dayDiff(dateStr) {
+    const parts = dateStr.split("-").map(Number);
+    const d = new Date(parts[0], parts[1] - 1, parts[2]);
+    return Math.round((d - TODAY) / 86400000);
+  }
+
+  dateLabel(dateStr) {
+    const diff = this.dayDiff(dateStr);
+    if (diff === 0) return "Today";
+    if (diff === 1) return "Tomorrow";
+    if (diff === -1) return "Yesterday";
+    if (diff < 0) return Math.abs(diff) + " days late";
+    const parts = dateStr.split("-").map(Number);
+    const d = new Date(parts[0], parts[1] - 1, parts[2]);
+    return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  }
+
+  bucket(item) {
+    if (item.isDone) return "Done";
+    const diff = this.dayDiff(item.limitDate);
+    if (diff < 0) return "Overdue";
+    if (diff === 0) return "Today";
+    return "Upcoming";
+  }
+
+  decorate(item) {
+    const overdue = !item.isDone && this.dayDiff(item.limitDate) < 0;
+    return {
+      id: item.id,
+      title: item.title,
+      description: item.description,
+      hasDescription: !!item.description && (this.props.showDescriptions ?? true),
+      dateLabel: this.dateLabel(item.limitDate),
+      isDone: item.isDone,
+      notDone: !item.isDone,
+      isOverdue: overdue,
+      isPlain: !overdue,
+      toggle: () => this.setState(s => ({ items: s.items.map(i => i.id === item.id ? { ...i, isDone: !i.isDone } : i) })),
+      edit: () => this.setState({ sheet: "edit", draft: { ...item } })
+    };
+  }
+
+  renderVals() {
+    const groupBy = this.props.groupBy ?? "date";
+    const showProgress = this.props.showProgress ?? true;
+    const q = this.state.query.trim().toLowerCase();
+    const all = this.state.items;
+
+    const matches = all.filter(i => {
+      if (this.state.view === "Today") return this.bucket(i) === "Today";
+      if (this.state.view === "Upcoming") return !i.isDone && this.dayDiff(i.limitDate) > 0;
+      if (this.state.view === "Done") return i.isDone;
+      return true;
+    }).filter(i => !q || i.title.toLowerCase().includes(q) || (i.description || "").toLowerCase().includes(q));
+
+    const sorted = matches.slice().sort((a, b) => a.limitDate.localeCompare(b.limitDate));
+    let groups;
+    if (groupBy === "none") {
+      groups = [{ label: this.state.view === "All" ? "All reminders" : this.state.view, count: sorted.length, items: sorted.map(i => this.decorate(i)) }];
+    } else if (groupBy === "status") {
+      groups = [["Open", sorted.filter(i => !i.isDone)], ["Completed", sorted.filter(i => i.isDone)]]
+        .filter(g => g[1].length)
+        .map(g => ({ label: g[0], count: g[1].length, items: g[1].map(i => this.decorate(i)) }));
+    } else {
+      const order = ["Overdue", "Today", "Upcoming", "Done"];
+      groups = order.map(name => {
+        const items = sorted.filter(i => this.bucket(i) === name);
+        return { label: name, count: items.length, items: items.map(i => this.decorate(i)) };
+      }).filter(g => g.items.length);
+    }
+
+    const counts = {
+      All: all.length,
+      Today: all.filter(i => this.bucket(i) === "Today").length,
+      Upcoming: all.filter(i => !i.isDone && this.dayDiff(i.limitDate) > 0).length,
+      Done: all.filter(i => i.isDone).length
+    };
+    const views = ["All", "Today", "Upcoming", "Done"].map(label => ({
+      label,
+      count: counts[label],
+      active: this.state.view === label,
+      inactive: this.state.view !== label,
+      select: () => this.setState({ view: label })
+    }));
+
+    const week = all.filter(i => this.dayDiff(i.limitDate) <= 7);
+    const weekDone = week.filter(i => i.isDone).length;
+    const pct = week.length ? Math.round((weekDone / week.length) * 100) : 0;
+    const overdueCount = all.filter(i => this.bucket(i) === "Overdue").length;
+
+    const layout = this.props.layout ?? "auto";
+    const mob = layout === "mobile" || (layout === "auto" && this.state.width < 760);
+    const d = this.state.draft;
+    const emptyByView = {
+      All: ["Nothing on the list", "Everything is clear. Add a reminder when something needs to come back to you."],
+      Today: ["Today is clear", "No reminders due today — check Upcoming to get ahead."],
+      Upcoming: ["Nothing scheduled", "No future reminders yet."],
+      Done: ["Nothing completed yet", "Tick something off and it will land here."]
+    };
+    const empty = q ? ["No matches", "No reminder matches “" + this.state.query + "”."] : emptyByView[this.state.view];
+    const target = this.state.confirmId ? all.find(i => i.id === this.state.confirmId) : null;
+
+    return {
+      isMobile: mob,
+      isWide: !mob,
+      safeTop: !!(this.props.safeArea ?? false),
+      todayLabel: TODAY.toLocaleDateString("en-US", { weekday: "long", month: "long", day: "numeric" }),
+      shortDateLabel: TODAY.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" }),
+      query: this.state.query,
+      onQuery: e => this.setState({ query: e.target.value }),
+      views,
+      groups,
+      isEmpty: !sorted.length,
+      emptyTitle: empty[0],
+      emptyBody: empty[1],
+      showProgress,
+      progressLabel: pct + "%",
+      progressWidth: pct + "%",
+      progressCaption: overdueCount ? overdueCount + (overdueCount === 1 ? " reminder is overdue" : " reminders are overdue") : weekDone + " of " + week.length + " done in the next 7 days",
+
+      startCreate: () => this.setState({ sheet: "create", draft: { title: "", description: "", limitDate: shift(1), isDone: false } }),
+      sheetOpen: !!this.state.sheet,
+      isEditing: this.state.sheet === "edit",
+      sheetTitle: this.state.sheet === "edit" ? "Edit reminder" : "New reminder",
+      saveLabel: this.state.sheet === "edit" ? "Save changes" : "Create reminder",
+      draftTitle: d ? d.title : "",
+      draftDescription: d ? d.description : "",
+      draftDate: d ? d.limitDate : "",
+      draftCheck: d && d.isDone ? "✓" : "",
+      draftStatusLabel: d && d.isDone ? "Done" : "Not done yet",
+      onDraftTitle: e => this.setState(s => ({ draft: { ...s.draft, title: e.target.value } })),
+      onDraftDescription: e => this.setState(s => ({ draft: { ...s.draft, description: e.target.value } })),
+      onDraftDate: e => this.setState(s => ({ draft: { ...s.draft, limitDate: e.target.value } })),
+      toggleDraftDone: () => this.setState(s => ({ draft: { ...s.draft, isDone: !s.draft.isDone } })),
+      closeSheet: () => this.setState({ sheet: null, draft: null }),
+      stop: e => e.stopPropagation(),
+      saveDraft: () => this.setState(s => {
+        const draft = s.draft;
+        if (!draft || !draft.title.trim()) return { sheet: null, draft: null };
+        if (draft.id) return { items: s.items.map(i => i.id === draft.id ? { ...draft } : i), sheet: null, draft: null };
+        return { items: s.items.concat([{ ...draft, id: s.nextId }]), nextId: s.nextId + 1, sheet: null, draft: null };
+      }),
+
+      askDelete: () => this.setState(s => ({ confirmId: s.draft ? s.draft.id : null })),
+      confirmOpen: !!this.state.confirmId,
+      confirmBody: target ? "“" + target.title + "” will be removed permanently." : "",
+      cancelDelete: () => this.setState({ confirmId: null }),
+      confirmDelete: () => this.setState(s => ({ items: s.items.filter(i => i.id !== s.confirmId), confirmId: null, sheet: null, draft: null }))
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/reminders-redesign/design-system.md
+++ b/docs/design/reminders-redesign/design-system.md
@@ -1,0 +1,42 @@
+# Reminders — Design System (binding for all designs in this project)
+
+All styling is inline (DC rules). These are the ONLY approved values — reuse them verbatim; don't invent new colors, fonts, radii, or sizes.
+
+## Color
+- Canvas: `#F3F0E9` (page bg) · Panel strip: `#EFEBE1`
+- Surface: `#FBFAF7` (cards, modals, inputs on canvas) · Input fill: `#F7F5F0`
+- Ink: `#1B1A17` (primary text, primary buttons) · Body-muted: `#6E6759` · Faint: `#8C8577` · Disabled/done text: `#9A9385`
+- Borders: `#E0DACD` (page dividers) · `#E7E2D6` (card) · `#DDD7C9` (inputs) · hover border: `#CFC7B5` / `#C6BDA9`
+- Accent (urgency/destructive/links/focus): `#B4451F`, hover `#8E3415`, tint bg `#F6E4DC`
+- Success/done: `#4C6B4F`, tint bg `#EDF1EC`
+- Overlay scrim: `rgba(27,26,23,0.34–0.42)`
+
+## Type
+- Display: `'Instrument Serif', serif` — page title 30px, section headers 22px (weight 400), modal titles 24–27px, stats 40px; italic for dates/asides
+- UI/body: `'DM Sans', system-ui, sans-serif` — body 15–15.5px, secondary 13.5–14.5px, pills/badges 12.5px
+- Labels: 11.5px, uppercase, letter-spacing 0.09–0.1em, color `#8C8577`
+- Google Fonts link required in every DC helmet (Instrument Serif + DM Sans)
+
+## Shape & space
+- Radii: pills/buttons `999px` · cards `14px` · modals `16–20px` · inputs `10px` · nav items `10px`
+- Card padding `16px 18px`; modal padding `28px`; page gutters `clamp(20px, 4vw, 48px)`
+- Sibling groups always flex/grid with `gap` (cards gap 10, sections gap 30, form fields gap 18)
+
+## Components
+- Primary button: ink bg, `#F7F5F0` text, pill radius, `padding 12–13px 20–26px`, hover → accent bg
+- Secondary button: transparent, `1px solid #DDD7C9`, pill, hover → ink border
+- Destructive: accent bg, hover `#8E3415`; text-danger variant: transparent, accent text
+- Inputs: `1px solid #DDD7C9`, bg `#F7F5F0`, radius 10, fixed `height: 48px` (textarea excepted); focus = 2px accent outline (suppressed inside search pill via `style-focus="outline: none"`)
+- Card row: surface bg, card border, radius 14, `align-items: center`
+- Status pills: overdue = accent text on `#F6E4DC`; neutral = `#6E6759` on `#F0EDE4`
+- Checkbox: 24px circle; done = solid `#4C6B4F` with white check; open = `1.6px solid #C6BDA9`
+- Modals: centered, max-width 400–560px, scrim + `sheetIn`/`fadeIn` keyframes
+
+## Interaction
+- Hover states on every clickable (`style-hover`); pointer cursor everywhere clickable, incl. date inputs
+- Min hit target 44px (52px FAB on mobile)
+- Mobile breakpoint: <760px → filter chips row, compressed progress strip, FAB; `layout` prop forces `mobile`/`desktop`
+
+## Reusability
+- `Reminders.dc.html` is the single source app; Desktop/Tablet/Mobile files are thin wrappers via `dc-import` (Mobile wraps in `IOSDevice` from `ios-frame.jsx`)
+- New screens: follow this file; copy patterns from `Reminders.dc.html` rather than restyling

--- a/docs/design/reminders-redesign/ios-frame.jsx
+++ b/docs/design/reminders-redesign/ios-frame.jsx
@@ -1,0 +1,352 @@
+// @ds-adherence-ignore -- omelette starter scaffold (raw elements/hex/px by design)
+// Copied omelette starter. Re-running copy_starter_component with this kind overwrites this file with the latest version (page content is unaffected).
+
+/* BEGIN USAGE */
+// iOS.jsx — Simplified iOS 26 (Liquid Glass) device frame
+// Based on the iOS 26 UI Kit + Figma status bar spec. No assets, no deps.
+// Exports (to window): IOSDevice, IOSStatusBar, IOSNavBar, IOSGlassPill, IOSList, IOSListRow, IOSKeyboard
+//
+// Usage — wrap your screen content in <IOSDevice> to get the bezel, status bar
+// and home indicator (props: title, dark, keyboard):
+//
+//   <IOSDevice title="Settings">
+//     ...your screen content...
+//   </IOSDevice>
+//   <IOSDevice dark title="Search" keyboard>…</IOSDevice>
+/* END USAGE */
+
+// ─────────────────────────────────────────────────────────────
+// Status bar
+// ─────────────────────────────────────────────────────────────
+function IOSStatusBar({ dark = false, time = '9:41' }) {
+  const c = dark ? '#fff' : '#000';
+  return (
+    <div style={{
+      display: 'flex', gap: 154, alignItems: 'center', justifyContent: 'center',
+      padding: '21px 24px 19px', boxSizing: 'border-box',
+      position: 'relative', zIndex: 20, width: '100%',
+    }}>
+      <div style={{ flex: 1, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', paddingTop: 1.5 }}>
+        <span style={{
+          fontFamily: '-apple-system, "SF Pro", system-ui', fontWeight: 590,
+          fontSize: 17, lineHeight: '22px', color: c,
+        }}>{time}</span>
+      </div>
+      <div style={{ flex: 1, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7, paddingTop: 1, paddingRight: 1 }}>
+        <svg width="19" height="12" viewBox="0 0 19 12">
+          <rect x="0" y="7.5" width="3.2" height="4.5" rx="0.7" fill={c}/>
+          <rect x="4.8" y="5" width="3.2" height="7" rx="0.7" fill={c}/>
+          <rect x="9.6" y="2.5" width="3.2" height="9.5" rx="0.7" fill={c}/>
+          <rect x="14.4" y="0" width="3.2" height="12" rx="0.7" fill={c}/>
+        </svg>
+        <svg width="17" height="12" viewBox="0 0 17 12">
+          <path d="M8.5 3.2C10.8 3.2 12.9 4.1 14.4 5.6L15.5 4.5C13.7 2.7 11.2 1.5 8.5 1.5C5.8 1.5 3.3 2.7 1.5 4.5L2.6 5.6C4.1 4.1 6.2 3.2 8.5 3.2Z" fill={c}/>
+          <path d="M8.5 6.8C9.9 6.8 11.1 7.3 12 8.2L13.1 7.1C11.8 5.9 10.2 5.1 8.5 5.1C6.8 5.1 5.2 5.9 3.9 7.1L5 8.2C5.9 7.3 7.1 6.8 8.5 6.8Z" fill={c}/>
+          <circle cx="8.5" cy="10.5" r="1.5" fill={c}/>
+        </svg>
+        <svg width="27" height="13" viewBox="0 0 27 13">
+          <rect x="0.5" y="0.5" width="23" height="12" rx="3.5" stroke={c} strokeOpacity="0.35" fill="none"/>
+          <rect x="2" y="2" width="20" height="9" rx="2" fill={c}/>
+          <path d="M25 4.5V8.5C25.8 8.2 26.5 7.2 26.5 6.5C26.5 5.8 25.8 4.8 25 4.5Z" fill={c} fillOpacity="0.4"/>
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Liquid glass pill — blur + tint + shine
+// ─────────────────────────────────────────────────────────────
+function IOSGlassPill({ children, dark = false, style = {} }) {
+  return (
+    <div style={{
+      height: 44, minWidth: 44, borderRadius: 9999,
+      position: 'relative', overflow: 'hidden',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      boxShadow: dark
+        ? '0 2px 6px rgba(0,0,0,0.35), 0 6px 16px rgba(0,0,0,0.2)'
+        : '0 1px 3px rgba(0,0,0,0.07), 0 3px 10px rgba(0,0,0,0.06)',
+      ...style,
+    }}>
+      {/* blur + tint */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 9999,
+        backdropFilter: 'blur(12px) saturate(180%)',
+        WebkitBackdropFilter: 'blur(12px) saturate(180%)',
+        background: dark ? 'rgba(120,120,128,0.28)' : 'rgba(255,255,255,0.5)',
+      }} />
+      {/* shine */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 9999,
+        boxShadow: dark
+          ? 'inset 1.5px 1.5px 1px rgba(255,255,255,0.15), inset -1px -1px 1px rgba(255,255,255,0.08)'
+          : 'inset 1.5px 1.5px 1px rgba(255,255,255,0.7), inset -1px -1px 1px rgba(255,255,255,0.4)',
+        border: dark ? '0.5px solid rgba(255,255,255,0.15)' : '0.5px solid rgba(0,0,0,0.06)',
+      }} />
+      <div style={{ position: 'relative', zIndex: 1, display: 'flex', alignItems: 'center', padding: '0 4px' }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Navigation bar — glass pills + large title
+// ─────────────────────────────────────────────────────────────
+function IOSNavBar({ title = 'Title', dark = false, trailingIcon = true }) {
+  const muted = dark ? 'rgba(255,255,255,0.6)' : '#404040';
+  const text = dark ? '#fff' : '#000';
+  const pillIcon = (content) => (
+    <IOSGlassPill dark={dark}>
+      <div style={{ width: 36, height: 36, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        {content}
+      </div>
+    </IOSGlassPill>
+  );
+  return (
+    <div style={{
+      display: 'flex', flexDirection: 'column', gap: 10,
+      paddingTop: 62, paddingBottom: 10, position: 'relative', zIndex: 5,
+    }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        padding: '0 16px',
+      }}>
+        {/* back chevron */}
+        {pillIcon(
+          <svg width="12" height="20" viewBox="0 0 12 20" fill="none" style={{ marginLeft: -1 }}>
+            <path d="M10 2L2 10l8 8" stroke={muted} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        )}
+        {/* trailing ellipsis */}
+        {trailingIcon && pillIcon(
+          <svg width="22" height="6" viewBox="0 0 22 6">
+            <circle cx="3" cy="3" r="2.5" fill={muted}/>
+            <circle cx="11" cy="3" r="2.5" fill={muted}/>
+            <circle cx="19" cy="3" r="2.5" fill={muted}/>
+          </svg>
+        )}
+      </div>
+      {/* large title */}
+      <div style={{
+        padding: '0 16px',
+        fontFamily: '-apple-system, system-ui',
+        fontSize: 34, fontWeight: 700, lineHeight: '41px',
+        color: text, letterSpacing: 0.4,
+      }}>{title}</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Grouped list (inset card, r:26) + row (52px)
+// ─────────────────────────────────────────────────────────────
+function IOSListRow({ title, detail, icon, chevron = true, isLast = false, dark = false }) {
+  const text = dark ? '#fff' : '#000';
+  const sec = dark ? 'rgba(235,235,245,0.6)' : 'rgba(60,60,67,0.6)';
+  const ter = dark ? 'rgba(235,235,245,0.3)' : 'rgba(60,60,67,0.3)';
+  const sep = dark ? 'rgba(84,84,88,0.65)' : 'rgba(60,60,67,0.12)';
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', minHeight: 52,
+      padding: '0 16px', position: 'relative',
+      fontFamily: '-apple-system, system-ui', fontSize: 17,
+      letterSpacing: -0.43,
+    }}>
+      {icon && (
+        <div style={{
+          width: 30, height: 30, borderRadius: 7, background: icon,
+          marginRight: 12, flexShrink: 0,
+        }} />
+      )}
+      <div style={{ flex: 1, color: text }}>{title}</div>
+      {detail && <span style={{ color: sec, marginRight: 6 }}>{detail}</span>}
+      {chevron && (
+        <svg width="8" height="14" viewBox="0 0 8 14" style={{ flexShrink: 0 }}>
+          <path d="M1 1l6 6-6 6" stroke={ter} strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+      )}
+      {!isLast && (
+        <div style={{
+          position: 'absolute', bottom: 0, right: 0,
+          left: icon ? 58 : 16, height: 0.5, background: sep,
+        }} />
+      )}
+    </div>
+  );
+}
+
+function IOSList({ header, children, dark = false }) {
+  const hc = dark ? 'rgba(235,235,245,0.6)' : 'rgba(60,60,67,0.6)';
+  const bg = dark ? '#1C1C1E' : '#fff';
+  return (
+    <div>
+      {header && (
+        <div style={{
+          fontFamily: '-apple-system, system-ui', fontSize: 13,
+          color: hc, textTransform: 'uppercase',
+          padding: '8px 36px 6px', letterSpacing: -0.08,
+        }}>{header}</div>
+      )}
+      <div style={{
+        background: bg, borderRadius: 26,
+        margin: '0 16px', overflow: 'hidden',
+      }}>{children}</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Device frame
+// ─────────────────────────────────────────────────────────────
+function IOSDevice({
+  children, width = 402, height = 874, dark = false,
+  title, keyboard = false,
+}) {
+  return (
+    // data-om-starter: inert presence marker — Claude Design's starter-usage
+    // probe reads it; it renders nothing. Keep it on this root element.
+    <div data-om-starter="ios-frame" style={{
+      width, height, borderRadius: 48, overflow: 'hidden',
+      position: 'relative', background: dark ? '#000' : '#F2F2F7',
+      boxShadow: '0 40px 80px rgba(0,0,0,0.18), 0 0 0 1px rgba(0,0,0,0.12)',
+      fontFamily: '-apple-system, system-ui, sans-serif',
+      WebkitFontSmoothing: 'antialiased',
+    }}>
+      {/* dynamic island */}
+      <div style={{
+        position: 'absolute', top: 11, left: '50%', transform: 'translateX(-50%)',
+        width: 126, height: 37, borderRadius: 24, background: '#000', zIndex: 50,
+      }} />
+      {/* status bar (absolute) */}
+      <div style={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: 10 }}>
+        <IOSStatusBar dark={dark} />
+      </div>
+      {/* nav + content */}
+      <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+        {title !== undefined && <IOSNavBar title={title} dark={dark} />}
+        <div style={{ flex: 1, overflow: 'auto' }}>{children}</div>
+        {keyboard && <IOSKeyboard dark={dark} />}
+      </div>
+      {/* home indicator — always on top */}
+      <div style={{
+        position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 60,
+        height: 34, display: 'flex', justifyContent: 'center', alignItems: 'flex-end',
+        paddingBottom: 8, pointerEvents: 'none',
+      }}>
+        <div style={{
+          width: 139, height: 5, borderRadius: 100,
+          background: dark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.25)',
+        }} />
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Keyboard — iOS 26 liquid glass
+// ─────────────────────────────────────────────────────────────
+function IOSKeyboard({ dark = false }) {
+  const glyph = dark ? 'rgba(255,255,255,0.7)' : '#595959';
+  const sugg = dark ? 'rgba(255,255,255,0.6)' : '#333';
+  const keyBg = dark ? 'rgba(255,255,255,0.22)' : 'rgba(255,255,255,0.85)';
+
+  // special-key icons
+  const icons = {
+    shift: <svg width="19" height="17" viewBox="0 0 19 17"><path d="M9.5 1L1 9.5h4.5V16h8V9.5H18L9.5 1z" fill={glyph}/></svg>,
+    del: <svg width="23" height="17" viewBox="0 0 23 17"><path d="M7 1h13a2 2 0 012 2v11a2 2 0 01-2 2H7l-6-7.5L7 1z" fill="none" stroke={glyph} strokeWidth="1.6" strokeLinejoin="round"/><path d="M10 5l7 7M17 5l-7 7" stroke={glyph} strokeWidth="1.6" strokeLinecap="round"/></svg>,
+    ret: <svg width="20" height="14" viewBox="0 0 20 14"><path d="M18 1v6H4m0 0l4-4M4 7l4 4" fill="none" stroke="#fff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/></svg>,
+  };
+
+  const key = (content, { w, flex, ret, fs = 25, k } = {}) => (
+    <div key={k} style={{
+      height: 42, borderRadius: 8.5,
+      flex: flex ? 1 : undefined, width: w, minWidth: 0,
+      background: ret ? '#08f' : keyBg,
+      boxShadow: '0 1px 0 rgba(0,0,0,0.075)',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      fontFamily: '-apple-system, "SF Compact", system-ui',
+      fontSize: fs, fontWeight: 458, color: ret ? '#fff' : glyph,
+    }}>{content}</div>
+  );
+
+  const row = (keys, pad = 0) => (
+    <div style={{ display: 'flex', gap: 6.5, justifyContent: 'center', padding: `0 ${pad}px` }}>
+      {keys.map(l => key(l, { flex: true, k: l }))}
+    </div>
+  );
+
+  return (
+    <div style={{
+      position: 'relative', zIndex: 15, borderRadius: 27, overflow: 'hidden',
+      padding: '11px 0 2px',
+      display: 'flex', flexDirection: 'column', alignItems: 'center',
+      boxShadow: dark
+        ? '0 -2px 20px rgba(0,0,0,0.09)'
+        : '0 -1px 6px rgba(0,0,0,0.018), 0 -3px 20px rgba(0,0,0,0.012)',
+    }}>
+      {/* liquid glass bg — same recipe as nav pills */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 27,
+        backdropFilter: 'blur(12px) saturate(180%)',
+        WebkitBackdropFilter: 'blur(12px) saturate(180%)',
+        background: dark ? 'rgba(120,120,128,0.14)' : 'rgba(255,255,255,0.25)',
+      }} />
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 27,
+        boxShadow: dark
+          ? 'inset 1.5px 1.5px 1px rgba(255,255,255,0.15)'
+          : 'inset 1.5px 1.5px 1px rgba(255,255,255,0.7), inset -1px -1px 1px rgba(255,255,255,0.4)',
+        border: dark ? '0.5px solid rgba(255,255,255,0.15)' : '0.5px solid rgba(0,0,0,0.06)',
+        pointerEvents: 'none',
+      }} />
+
+      {/* autocorrect bar */}
+      <div style={{
+        display: 'flex', gap: 20, alignItems: 'center',
+        padding: '8px 22px 13px', width: '100%', boxSizing: 'border-box',
+        position: 'relative',
+      }}>
+        {['"The"', 'the', 'to'].map((w, i) => (
+          <React.Fragment key={i}>
+            {i > 0 && <div style={{ width: 1, height: 25, background: '#ccc', opacity: 0.3 }} />}
+            <div style={{
+              flex: 1, textAlign: 'center',
+              fontFamily: '-apple-system, system-ui', fontSize: 17,
+              color: sugg, letterSpacing: -0.43, lineHeight: '22px',
+            }}>{w}</div>
+          </React.Fragment>
+        ))}
+      </div>
+
+      {/* key layout */}
+      <div style={{
+        display: 'flex', flexDirection: 'column', gap: 13,
+        padding: '0 6.5px', width: '100%', boxSizing: 'border-box',
+        position: 'relative',
+      }}>
+        {row(['q','w','e','r','t','y','u','i','o','p'])}
+        {row(['a','s','d','f','g','h','j','k','l'], 20)}
+        <div style={{ display: 'flex', gap: 14.25, alignItems: 'center' }}>
+          {key(icons.shift, { w: 45, k: 'shift' })}
+          <div style={{ display: 'flex', gap: 6.5, flex: 1 }}>
+            {['z','x','c','v','b','n','m'].map(l => key(l, { flex: true, k: l }))}
+          </div>
+          {key(icons.del, { w: 45, k: 'del' })}
+        </div>
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          {key('ABC', { w: 92.25, fs: 18, k: 'abc' })}
+          {key('', { flex: true, k: 'space' })}
+          {key(icons.ret, { w: 92.25, ret: true, k: 'ret' })}
+        </div>
+      </div>
+
+      {/* bottom spacer (emoji+mic area, icons omitted) */}
+      <div style={{ height: 56, width: '100%', position: 'relative' }} />
+    </div>
+  );
+}
+
+Object.assign(window, {
+  IOSDevice, IOSStatusBar, IOSNavBar, IOSGlassPill, IOSList, IOSListRow, IOSKeyboard,
+});


### PR DESCRIPTION
## Summary
- Adds design handoff for the frontend redesign to docs/design/reminders-redesign/
- README.md: full spec (screens, interactions, state), design-system.md: tokens, *.dc.html: high-fidelity prototypes, ios-frame.jsx: presentation-only device frame
- Implementation tracked in #322

## Test plan
- [ ] Docs only; CI green