### PR TITLE
docs: document project board workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,15 @@ Five dimensions. Every issue gets exactly one type label; add scope/initiative/s
 | Status | `triage`, `hold`, `duplicate`, `invalid` | Workflow state |
 | Phase | `phase-1`, `phase-2`, `phase-3` | Audit plan only |
 
+### Project board
+
+[Project 7](https://github.com/users/jumperck/projects/7) is the execution view of the backlog (see ADR-0002). Columns: Backlog, Todo, In Progress, Done. Extra fields: Priority (P0/P1/P2), Initiative (audit/redesign/learning).
+
+- When claiming an issue, move its board item to In Progress.
+- New issues are auto-added to the board; set Priority and Initiative when triaging.
+- Closed issues move to Done automatically; do not set Done by hand.
+- Todo means prioritized and ready to start; Backlog means not yet prioritized.
+
 ## Architecture Decision Records (ADRs)
 
 Decisions persist in `docs/adr/` so all agents share the same memory. Format: `NNNN-short-title.md` (see `docs/adr/0000-template.md`).

--- a/docs/adr/0002-project-board.md
+++ b/docs/adr/0002-project-board.md
@@ -1,0 +1,22 @@
+# ADR-0002: GitHub Project board as execution view of the backlog
+
+- **Status**: accepted
+- **Date**: 2026-07-26
+
+## Context
+
+GitHub Issues holds the backlog (ADR-0001), but with 40+ open issues across audit, redesign, and learning initiatives, labels alone do not show what is prioritized, in flight, or next. Multiple agents work in parallel and need a shared, current picture of execution state.
+
+## Decision
+
+- GitHub Project 7 ("Reminders") is the single execution board for `jumperck/Reminders`.
+- Status columns: Backlog (not prioritized), Todo (prioritized, ready), In Progress (claimed), Done (closed).
+- Extra single-select fields: Priority (P0/P1/P2) and Initiative (audit/redesign/learning), mirroring initiative labels.
+- Built-in workflows keep the board current: issues auto-added on open, moved to Done on close, back to Todo on reopen.
+- Agents move their item to In Progress when claiming an issue and set Priority/Initiative when triaging new issues. Done is automated, never set by hand.
+
+## Consequences
+
+- Easier: at-a-glance execution state for humans and agents; prioritization separate from labels.
+- Harder: one more surface to keep honest; stale In Progress items need periodic sweep.
+- Watch: board and labels drifting apart on initiative; labels stay the source of truth for taxonomy.


### PR DESCRIPTION
## Summary
- Project 7 set up as execution board: Backlog/Todo/In Progress/Done, Priority (P0-P2), Initiative (audit/redesign/learning), all 43 open issues added and triaged
- CLAUDE.md Backlog section gains board rules for agents
- ADR-0002 records the decision

Closes #342