### PR TITLE
docs: add project planning section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,7 @@ We welcome contributions! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for det
 ## Support
 
 If you encounter any issues or have suggestions, we encourage you to open an issue on the [GitHub Issues](https://github.com/jumperck/Reminders/issues) page.
+
+## Project Planning
+
+Work is planned and tracked on the [Reminders project board](https://github.com/users/jumperck/projects/7). Progress updates follow GitHub's [sharing project updates](https://docs.github.com/en/issues/planning-and-tracking-with-projects/sharing-project-updates) guide.


### PR DESCRIPTION
## Summary
- README bottom links project board 7 and GitHub sharing-project-updates guide

Closes #346