### PR TITLE
fix(api): remove blocking .Result calls, make service chain async

### DIFF
--- a/src/server/api/dotnet/Reminders.Api/Controllers/RemindersController.cs
+++ b/src/server/api/dotnet/Reminders.Api/Controllers/RemindersController.cs
@@ -23,21 +23,21 @@ public class RemindersController
 
     // GET: api/Reminders/5
     [HttpGet("{id}", Name = "Get")]
-    public IActionResult Get(Guid id) =>
-        Ok(remindersService.Get(id));
+    public async Task<IActionResult> Get(Guid id) =>
+        Ok(await remindersService.GetAsync(id));
 
     // POST: api/Reminders
     [HttpPost]
-    public ReminderViewModel Post([FromBody] ReminderViewModel reminderViewModel) =>
-        remindersService.Insert(reminderViewModel);
+    public Task<ReminderViewModel> Post([FromBody] ReminderViewModel reminderViewModel) =>
+        remindersService.InsertAsync(reminderViewModel);
 
     // PUT: api/Reminders/5
     [HttpPut("{id}")]
-    public ReminderViewModel Put(Guid id, [FromBody] ReminderViewModel reminderViewModel) =>
-        remindersService.Edit(id, reminderViewModel);
+    public Task<ReminderViewModel> Put(Guid id, [FromBody] ReminderViewModel reminderViewModel) =>
+        remindersService.EditAsync(id, reminderViewModel);
 
     // DELETE: api/Reminders/5
     [HttpDelete("{id}")]
-    public void Delete(Guid id) =>
-        remindersService.Delete(id);
+    public Task Delete(Guid id) =>
+        remindersService.DeleteAsync(id);
 }

--- a/src/server/api/dotnet/Reminders.Api/Layers/Application/Contracts/IRemindersService.cs
+++ b/src/server/api/dotnet/Reminders.Api/Layers/Application/Contracts/IRemindersService.cs
@@ -1,11 +1,11 @@
-﻿namespace Reminders.Application.Contracts;
+namespace Reminders.Application.Contracts;
 
 public interface IRemindersService
 {
-    ReminderViewModel Insert(ReminderViewModel reminderViewModel);
-    ReminderViewModel Edit(Guid id, ReminderViewModel reminderViewModel);
-    void Delete(Guid id);
+    Task<ReminderViewModel> InsertAsync(ReminderViewModel reminderViewModel);
+    Task<ReminderViewModel> EditAsync(Guid id, ReminderViewModel reminderViewModel);
+    Task DeleteAsync(Guid id);
 
     IQueryable<ReminderViewModel> Get();
-    ReminderViewModel Get(Guid id);
+    Task<ReminderViewModel> GetAsync(Guid id);
 }

--- a/src/server/api/dotnet/Reminders.Api/Layers/Application/Services/RemindersService.cs
+++ b/src/server/api/dotnet/Reminders.Api/Layers/Application/Services/RemindersService.cs
@@ -26,7 +26,7 @@ public class RemindersService
         this.unitOfWork = unitOfWork;
     }
 
-    public ReminderViewModel Insert(ReminderViewModel reminderViewModel)
+    public async Task<ReminderViewModel> InsertAsync(ReminderViewModel reminderViewModel)
     {
         reminderViewModel.IsDone = false;
 
@@ -45,8 +45,8 @@ public class RemindersService
         if (reminder.Title is not null)
         {
             var chainId = 0; // TODO: This will need to stored in a separated way.
-            var transactionHash = remindersBlockchainService.CreateReminderAsync(reminder.Title).Result;
-            var output = remindersBlockchainService.GetReminderAsync(chainId).Result;
+            var transactionHash = await remindersBlockchainService.CreateReminderAsync(reminder.Title);
+            var output = await remindersBlockchainService.GetReminderAsync(chainId);
 
             this.logger.LogInformation($"Blockchain: {output.Text} - {output.Owner} - {transactionHash}");
         }
@@ -57,7 +57,7 @@ public class RemindersService
         return mapper.Map<ReminderViewModel>(reminder);
     }
 
-    public ReminderViewModel Edit(
+    public async Task<ReminderViewModel> EditAsync(
       Guid id,
       ReminderViewModel reminderViewModel)
     {
@@ -76,8 +76,8 @@ public class RemindersService
         if (reminder.Title is not null)
         {
             var chainId = 0; // TODO: This will need to stored in a separated way.
-            var transactionHash = remindersBlockchainService.UpdateReminderAsync(chainId, reminder.Title).Result;
-            var output = remindersBlockchainService.GetReminderAsync(chainId).Result;
+            var transactionHash = await remindersBlockchainService.UpdateReminderAsync(chainId, reminder.Title);
+            var output = await remindersBlockchainService.GetReminderAsync(chainId);
 
             this.logger.LogInformation($"Blockchain: {output.Text} - {output.Owner} - {transactionHash}");
         }
@@ -87,7 +87,7 @@ public class RemindersService
         return mapper.Map<ReminderViewModel>(reminder);
     }
 
-    public void Delete(Guid id)
+    public async Task DeleteAsync(Guid id)
     {
         if (!remindersRepository.Exists(id))
             throw new RemindersApplicationException(ValidationStatus.NotFound, RemindersResources.NotFound);
@@ -99,8 +99,8 @@ public class RemindersService
             reminderData.Delete();
 
             var chainId = 0; // TODO: This will need to stored in a separated way.
-            var output = remindersBlockchainService.GetReminderAsync(chainId).Result;
-            remindersBlockchainService.DeleteReminderAsync(chainId);
+            var output = await remindersBlockchainService.GetReminderAsync(chainId);
+            await remindersBlockchainService.DeleteReminderAsync(chainId);
 
             this.logger.LogInformation($"Blockchain: {output.Text} - {output.Owner}");
 
@@ -126,14 +126,14 @@ public class RemindersService
         return remindersViewModel;
     }
 
-    public ReminderViewModel Get(Guid id)
+    public async Task<ReminderViewModel> GetAsync(Guid id)
     {
         var reminder = remindersRepository
             .Get()
             .FirstOrDefault(reminder => reminder.Id == id && !reminder.IsDeleted);
 
         var chainId = 0; // TODO: This will need to stored in a separated way.
-        var output = remindersBlockchainService.GetReminderAsync(chainId).Result;
+        var output = await remindersBlockchainService.GetReminderAsync(chainId);
 
         this.logger.LogInformation($"Blockchain: {output.Text} - {output.Owner}");
 

--- a/src/test/cypress/cypress/e2e/api-dotnet.cy.js
+++ b/src/test/cypress/cypress/e2e/api-dotnet.cy.js
@@ -1,0 +1,124 @@
+// E2E coverage for the .NET API (no UI, no intercepts: real HTTP against the running API)
+// Requires the api profile running: docker compose --profile api up -d
+// API base URL comes from CYPRESS_apiUrl (default http://localhost:5000)
+
+const api = () => Cypress.env('apiUrl')
+
+const futureDate = (days = 7) =>
+  new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString()
+
+describe('.NET API', { tags: '@api' }, () => {
+  context('GET /api/reminders', () => {
+    it('returns 200 with a list', () => {
+      cy.request(`${api()}/api/reminders`).then((response) => {
+        expect(response.status).to.eq(200)
+        expect(response.body).to.be.an('array')
+      })
+    })
+
+    it('returns the reminders count', () => {
+      cy.request(`${api()}/api/reminders/count`).then((response) => {
+        expect(response.status).to.eq(200)
+        expect(response.body).to.be.a('number')
+      })
+    })
+  })
+
+  context('CRUD lifecycle', () => {
+    it('creates, reads, updates and deletes a reminder', () => {
+      const reminder = {
+        title: 'Cypress API test',
+        description: 'Created by api-dotnet.cy.js',
+        limitDate: futureDate(),
+        isDone: false,
+      }
+
+      // CREATE
+      cy.request('POST', `${api()}/api/reminders`, reminder)
+        .then((response) => {
+          expect(response.status).to.eq(200)
+          expect(response.body.id).to.be.a('string').and.not.be.empty
+          expect(response.body.title).to.eq(reminder.title)
+          expect(response.body.isDone).to.be.false
+          return cy.wrap(response.body.id)
+        })
+        .then((id) => {
+          // READ
+          cy.request(`${api()}/api/reminders/${id}`).then((response) => {
+            expect(response.status).to.eq(200)
+            expect(response.body.id).to.eq(id)
+            expect(response.body.title).to.eq(reminder.title)
+          })
+
+          // UPDATE
+          const updated = {
+            ...reminder,
+            id,
+            title: 'Cypress API test updated',
+            isDone: true,
+          }
+          cy.request('PUT', `${api()}/api/reminders/${id}`, updated).then((response) => {
+            expect(response.status).to.eq(200)
+            expect(response.body.title).to.eq(updated.title)
+            expect(response.body.isDone).to.be.true
+          })
+
+          // DELETE (soft delete: reminder leaves the list)
+          cy.request('DELETE', `${api()}/api/reminders/${id}`).then((response) => {
+            expect(response.status).to.eq(200)
+          })
+
+          cy.request(`${api()}/api/reminders`).then((response) => {
+            const ids = response.body.map((r) => r.id)
+            expect(ids).to.not.include(id)
+          })
+        })
+    })
+  })
+
+  context('Validation', () => {
+    it('rejects a reminder with a past limit date', () => {
+      cy.request({
+        method: 'POST',
+        url: `${api()}/api/reminders`,
+        body: {
+          title: 'Invalid reminder',
+          description: 'Limit date in the past',
+          limitDate: '2020-01-01T00:00:00Z',
+          isDone: false,
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400)
+        expect(response.body.errors).to.have.property('LimitDate.Date')
+      })
+    })
+
+    it('rejects an update when route id and body id do not match', () => {
+      cy.request({
+        method: 'PUT',
+        url: `${api()}/api/reminders/00000000-0000-0000-0000-000000000001`,
+        body: {
+          id: '00000000-0000-0000-0000-000000000002',
+          title: 'Mismatch',
+          description: 'Ids do not match',
+          limitDate: futureDate(),
+          isDone: false,
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(409)
+      })
+    })
+
+    it('returns 404 for deleting a nonexistent reminder', () => {
+      cy.request({
+        method: 'DELETE',
+        url: `${api()}/api/reminders/00000000-0000-0000-0000-00000000dead`,
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404)
+      })
+    })
+  })
+})

--- a/src/test/cypress/cypress/support/e2e.js
+++ b/src/test/cypress/cypress/support/e2e.js
@@ -19,5 +19,7 @@ import './commands'
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 
-// Add grep support
-import '@cypress/grep'
+// Add grep support (must be called to register the filter)
+import registerCypressGrep from '@cypress/grep'
+
+registerCypressGrep()

--- a/src/test/server/dotnet/Reminders.Application.Test/Controllers/RemindersControllerUnitTest.cs
+++ b/src/test/server/dotnet/Reminders.Application.Test/Controllers/RemindersControllerUnitTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -149,7 +150,7 @@ namespace Reminders.Application.Test.Controllers
         #region GET By Id Tests
 
         [TestMethod]
-        public void Should_GetById_ReturnOkResult_WithReminder()
+        public async Task Should_GetById_ReturnOkResult_WithReminder()
         {
             // arrange
             var reminderId = Guid.NewGuid();
@@ -161,11 +162,11 @@ namespace Reminders.Application.Test.Controllers
             };
 
             mockRemindersService
-                .Setup(s => s.Get(reminderId))
-                .Returns(expectedReminder);
+                .Setup(s => s.GetAsync(reminderId))
+                .ReturnsAsync(expectedReminder);
 
             // act
-            var result = controller.Get(reminderId);
+            var result = await controller.Get(reminderId);
 
             // assert
             Assert.IsInstanceOfType(result, typeof(OkObjectResult));
@@ -177,21 +178,21 @@ namespace Reminders.Application.Test.Controllers
             Assert.AreEqual(reminderId, reminder.Id);
             Assert.AreEqual("Test Reminder", reminder.Title);
             
-            mockRemindersService.Verify(s => s.Get(reminderId), Times.Once);
+            mockRemindersService.Verify(s => s.GetAsync(reminderId), Times.Once);
         }
 
         [TestMethod]
-        public void Should_GetById_ReturnOkResult_WithNull_WhenNotFound()
+        public async Task Should_GetById_ReturnOkResult_WithNull_WhenNotFound()
         {
             // arrange
             var reminderId = Guid.NewGuid();
 
             mockRemindersService
-                .Setup(s => s.Get(reminderId))
-                .Returns((ReminderViewModel)null);
+                .Setup(s => s.GetAsync(reminderId))
+                .ReturnsAsync((ReminderViewModel)null);
 
             // act
-            var result = controller.Get(reminderId);
+            var result = await controller.Get(reminderId);
 
             // assert
             Assert.IsInstanceOfType(result, typeof(OkObjectResult));
@@ -205,7 +206,7 @@ namespace Reminders.Application.Test.Controllers
         #region POST Tests
 
         [TestMethod]
-        public void Should_Post_ReturnCreatedReminder()
+        public async Task Should_Post_ReturnCreatedReminder()
         {
             // arrange
             var inputReminder = new ReminderViewModel
@@ -224,18 +225,18 @@ namespace Reminders.Application.Test.Controllers
             };
 
             mockRemindersService
-                .Setup(s => s.Insert(inputReminder))
-                .Returns(createdReminder);
+                .Setup(s => s.InsertAsync(inputReminder))
+                .ReturnsAsync(createdReminder);
 
             // act
-            var result = controller.Post(inputReminder);
+            var result = await controller.Post(inputReminder);
 
             // assert
             Assert.IsNotNull(result);
             Assert.AreEqual(createdReminder.Id, result.Id);
             Assert.AreEqual(createdReminder.Title, result.Title);
             
-            mockRemindersService.Verify(s => s.Insert(inputReminder), Times.Once);
+            mockRemindersService.Verify(s => s.InsertAsync(inputReminder), Times.Once);
         }
 
         #endregion
@@ -243,7 +244,7 @@ namespace Reminders.Application.Test.Controllers
         #region PUT Tests
 
         [TestMethod]
-        public void Should_Put_ReturnUpdatedReminder()
+        public async Task Should_Put_ReturnUpdatedReminder()
         {
             // arrange
             var reminderId = Guid.NewGuid();
@@ -264,18 +265,18 @@ namespace Reminders.Application.Test.Controllers
             };
 
             mockRemindersService
-                .Setup(s => s.Edit(reminderId, inputReminder))
-                .Returns(updatedReminder);
+                .Setup(s => s.EditAsync(reminderId, inputReminder))
+                .ReturnsAsync(updatedReminder);
 
             // act
-            var result = controller.Put(reminderId, inputReminder);
+            var result = await controller.Put(reminderId, inputReminder);
 
             // assert
             Assert.IsNotNull(result);
             Assert.AreEqual(reminderId, result.Id);
             Assert.AreEqual("Updated Reminder", result.Title);
             
-            mockRemindersService.Verify(s => s.Edit(reminderId, inputReminder), Times.Once);
+            mockRemindersService.Verify(s => s.EditAsync(reminderId, inputReminder), Times.Once);
         }
 
         #endregion
@@ -283,19 +284,20 @@ namespace Reminders.Application.Test.Controllers
         #region DELETE Tests
 
         [TestMethod]
-        public void Should_Delete_CallServiceDelete()
+        public async Task Should_Delete_CallServiceDelete()
         {
             // arrange
             var reminderId = Guid.NewGuid();
 
             mockRemindersService
-                .Setup(s => s.Delete(reminderId));
+                .Setup(s => s.DeleteAsync(reminderId))
+                .Returns(Task.CompletedTask);
 
             // act
-            controller.Delete(reminderId);
+            await controller.Delete(reminderId);
 
             // assert
-            mockRemindersService.Verify(s => s.Delete(reminderId), Times.Once);
+            mockRemindersService.Verify(s => s.DeleteAsync(reminderId), Times.Once);
         }
 
         #endregion

--- a/src/test/server/dotnet/Reminders.Application.Test/Reminders/ReminderServiceUnitTest.cs
+++ b/src/test/server/dotnet/Reminders.Application.Test/Reminders/ReminderServiceUnitTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using AutoMapper;
 using FluentValidation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -94,7 +95,7 @@ namespace Reminders.Application.Test
 
         [Timeout(1000)]
         [TestMethod]
-        public void Should_Insert()
+        public async Task Should_Insert()
         {
             // arrange
             var reminder = new ReminderViewModel()
@@ -107,7 +108,7 @@ namespace Reminders.Application.Test
             // act
             var service = GetRemindersService();
 
-            service.Insert(reminder);
+            await service.InsertAsync(reminder);
 
             // assert
             repositoryMock.Verify(repository =>
@@ -121,7 +122,7 @@ namespace Reminders.Application.Test
 
         [Timeout(1000)]
         [TestMethod]
-        public void Should_IsDoneAsFalseOnInsert()
+        public async Task Should_IsDoneAsFalseOnInsert()
         {
             // arrange
             var reminderViewModel = new ReminderViewModel
@@ -135,7 +136,7 @@ namespace Reminders.Application.Test
             // act
             var service = GetRemindersService();
 
-            service.Insert(reminderViewModel);
+            await service.InsertAsync(reminderViewModel);
 
             // assert
             repositoryMock.Verify(repository =>
@@ -145,7 +146,7 @@ namespace Reminders.Application.Test
 
         [Timeout(1000)]
         [TestMethod]
-        public void Should_LimitDateAfterTodayOnInsert()
+        public async Task Should_LimitDateAfterTodayOnInsert()
         {
             // arrange
             var reminderViewModel = new ReminderViewModel
@@ -158,7 +159,7 @@ namespace Reminders.Application.Test
             // act
             var service = GetRemindersService();
 
-            var exception = Assert.ThrowsException<ValidationException>(() => service.Insert(reminderViewModel));
+            var exception = await Assert.ThrowsExceptionAsync<ValidationException>(() => service.InsertAsync(reminderViewModel));
 
             // assert
             Assert.IsTrue(exception.Message.Contains(RemindersResources.InvalidLimitDate));
@@ -170,7 +171,7 @@ namespace Reminders.Application.Test
 
         [Timeout(1000)]
         [TestMethod]
-        public void Should_Edit()
+        public async Task Should_Edit()
         {
             // arrange
             var reminder = new ReminderViewModel()
@@ -188,7 +189,7 @@ namespace Reminders.Application.Test
             // act
             var service = GetRemindersService();
 
-            service.Edit(reminder.Id.Value, reminder);
+            await service.EditAsync(reminder.Id.Value, reminder);
 
             // assert
             repositoryMock.Verify(repository =>
@@ -201,7 +202,7 @@ namespace Reminders.Application.Test
 
         [Timeout(1000)]
         [TestMethod]
-        public void Should_LimitDateAfterTodayOnEdit()
+        public async Task Should_LimitDateAfterTodayOnEdit()
         {
             // arrange
             var reminder = new ReminderViewModel()
@@ -215,7 +216,7 @@ namespace Reminders.Application.Test
             // act
             var service = GetRemindersService();
 
-            var exception = Assert.ThrowsException<ValidationException>(() => service.Edit(reminder.Id.Value, reminder));
+            var exception = await Assert.ThrowsExceptionAsync<ValidationException>(() => service.EditAsync(reminder.Id.Value, reminder));
 
             // assert
             Assert.IsTrue(exception.Message.Contains(RemindersResources.InvalidLimitDate));
@@ -223,7 +224,7 @@ namespace Reminders.Application.Test
 
         [Timeout(1000)]
         [TestMethod]
-        public void Should_NotFoundOnEdit()
+        public async Task Should_NotFoundOnEdit()
         {
             // arrange
             var reminder = new ReminderViewModel()
@@ -241,8 +242,8 @@ namespace Reminders.Application.Test
             // act
             var service = GetRemindersService();
 
-            var exception = Assert.ThrowsException<RemindersApplicationException>(() =>
-               service.Edit(reminder.Id.Value, reminder));
+            var exception = await Assert.ThrowsExceptionAsync<RemindersApplicationException>(() =>
+               service.EditAsync(reminder.Id.Value, reminder));
 
             // assert
             Assert.IsTrue(exception.StatusCode == ValidationStatus.NotFound);
@@ -251,7 +252,7 @@ namespace Reminders.Application.Test
 
         [Timeout(1000)]
         [TestMethod]
-        public void Should_IdsDoNotMatchOnEdit()
+        public async Task Should_IdsDoNotMatchOnEdit()
         {
             // arrange
             var reminder = new ReminderViewModel()
@@ -269,8 +270,8 @@ namespace Reminders.Application.Test
             // act
             var service = GetRemindersService();
 
-            var exception = Assert.ThrowsException<RemindersApplicationException>(() =>
-               service.Edit(Guid.NewGuid(), reminder));
+            var exception = await Assert.ThrowsExceptionAsync<RemindersApplicationException>(() =>
+               service.EditAsync(Guid.NewGuid(), reminder));
 
             // assert
             Assert.IsTrue(exception.StatusCode == ValidationStatus.IdsDoNotMatch);
@@ -283,7 +284,7 @@ namespace Reminders.Application.Test
 
         [Timeout(1000)]
         [TestMethod]
-        public void Should_Delete()
+        public async Task Should_Delete()
         {
             // arrange
             var reminder = new Reminder("My Title", "My Description", DateTime.UtcNow, false);
@@ -299,7 +300,7 @@ namespace Reminders.Application.Test
             // act
             var service = GetRemindersService();
 
-            service.Delete(reminder.Id);
+            await service.DeleteAsync(reminder.Id);
 
             // assert
             repositoryMock
@@ -315,7 +316,7 @@ namespace Reminders.Application.Test
 
         [Timeout(1000)]
         [TestMethod]
-        public void Should_NotFoundOnDelete()
+        public async Task Should_NotFoundOnDelete()
         {
             // arrange
             repositoryMock
@@ -325,8 +326,8 @@ namespace Reminders.Application.Test
             // act
             var service = GetRemindersService();
 
-            var exception = Assert.ThrowsException<RemindersApplicationException>(() =>
-               service.Delete(Guid.NewGuid()));
+            var exception = await Assert.ThrowsExceptionAsync<RemindersApplicationException>(() =>
+               service.DeleteAsync(Guid.NewGuid()));
 
             // assert
             Assert.IsTrue(exception.StatusCode == ValidationStatus.NotFound);
@@ -393,7 +394,7 @@ namespace Reminders.Application.Test
 
         [Timeout(1000)]
         [TestMethod]
-        public void Should_GetById()
+        public async Task Should_GetById()
         {
             // arrange
             var reminder = new Reminder("My Title", "My Description", DateTime.UtcNow, false);
@@ -408,7 +409,7 @@ namespace Reminders.Application.Test
             var service = GetRemindersService();
 
             // act
-            var result = service.Get(reminder.Id);
+            var result = await service.GetAsync(reminder.Id);
 
             // assert
             Assert.AreEqual(reminder.Title, result.Title);
@@ -416,7 +417,7 @@ namespace Reminders.Application.Test
 
         [Timeout(1000)]
         [TestMethod]
-        public void Should_NotGetById()
+        public async Task Should_NotGetById()
         {
             // arrange
             var reminder = new Reminder("My Title", "My Description", DateTime.UtcNow, false);
@@ -433,7 +434,7 @@ namespace Reminders.Application.Test
             var service = GetRemindersService();
 
             // act
-            var result = service.Get(reminder.Id);
+            var result = await service.GetAsync(reminder.Id);
 
             // assert
             Assert.IsNull(result);


### PR DESCRIPTION
## Summary
- Removes all blocking `.Result` calls on blockchain methods in `RemindersService` (deadlock risk, thread starvation): `Insert`, `Edit`, `Delete` and `Get(id)` are now async end to end (`IRemindersService`, service, controller).
- Also awaits the previously fire-and-forget `DeleteReminderAsync` in the delete path.
- Adds `api-dotnet.cy.js`: real cypress coverage for the .NET API via `cy.request` (list, count, full CRUD lifecycle, validation 400/409/404). All previous specs only tested mocked responses.

Closes #299

## Test plan
- [x] `dotnet test` Reminders.Application.Test: 47/47 passing
- [x] `npx cypress run --spec cypress/e2e/api-dotnet.cy.js` against `docker compose --profile api` stack: 6/6 passing