### PR TITLE
docs: add product vision and PRD workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -36,7 +36,7 @@ body:
   - type: input
     id: adr
     attributes:
-      label: Related ADR or Discussion
-      description: Link if this implements or changes a recorded decision.
+      label: Related PRD, ADR, or Discussion
+      description: Link if this implements a PRD or a recorded decision.
     validations:
       required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,9 @@
 
 <!-- Motivation, if not obvious from the issue -->
 
-## Related ADR
+## Related PRD / ADR
 
-<!-- Link docs/adr/NNNN-*.md if this implements or changes a recorded decision; write "none" otherwise -->
+<!-- Link docs/product/NNNN-*.md or docs/adr/NNNN-*.md if this implements a PRD or a recorded decision; write "none" otherwise -->
 
 ## How to test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,13 @@ Decisions persist in `docs/adr/` so all agents share the same memory. Format: `N
 - Read existing ADRs before proposing changes that might contradict them. Superseding an old ADR: new ADR references it, old one gets status `superseded`.
 - ADRs are short: context, decision, consequences. One page max.
 
+## Product Docs (PRDs)
+
+Product intent lives in `docs/product/` (vision, PRD template, index). Feature-sized work traces to a one-page PRD; small fixes and chores do not (see ADR-0006).
+
+- Flow: Ideas discussion, then PRD, then ADRs during implementation, then issues/PRs/release.
+- Agents keep PRD status current (draft, active, shipped, validated) and fill the Validation section with evidence after release.
+
 ## Multi-Agent Coordination
 
 Multiple agents may work this repo in parallel. Rules:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,14 +23,15 @@ This is a learning project, and we welcome contributions from developers of all 
 Every change follows the same path:
 
 1. **Discussion (RFC)**: questions and ideas that need debate start as a [GitHub Discussion](https://github.com/jumperck/Reminders/discussions).
-2. **ADR**: decisions that shape architecture, workflow, or tooling are recorded in [docs/adr/](docs/adr/README.md) before implementation.
-3. **Issue**: every piece of work maps to a GitHub Issue with explicit acceptance criteria. Check open issues before proposing new work.
-4. **Branch**: short-lived branch off `main`, named `<type>/<short-description>` (e.g. `feat/redis-cache`).
-5. **PR**: small and focused, follows the PR template, references the issue (`Closes #123`).
-6. **Review**: maintainer review is required (CODEOWNERS); CI must be green.
-7. **Merge**: squash merge onto `main`, which must always stay releasable.
+2. **PRD**: feature-sized work gets a one-page PRD in [docs/product/](docs/product/README.md) capturing problem, users, success criteria, and scope before implementation.
+3. **ADR**: decisions that shape architecture, workflow, or tooling are recorded in [docs/adr/](docs/adr/README.md) before implementation.
+4. **Issue**: every piece of work maps to a GitHub Issue with explicit acceptance criteria. Check open issues before proposing new work.
+5. **Branch**: short-lived branch off `main`, named `<type>/<short-description>` (e.g. `feat/redis-cache`).
+6. **PR**: small and focused, follows the PR template, references the issue (`Closes #123`).
+7. **Review**: maintainer review is required (CODEOWNERS); CI must be green.
+8. **Merge**: squash merge onto `main`, which must always stay releasable.
 
-Small fixes can skip steps 1-2 and start at the issue. See [ADR-0001](docs/adr/0001-development-workflow.md) for the reasoning behind this workflow.
+Small fixes can skip steps 1-3 and start at the issue. See [ADR-0001](docs/adr/0001-development-workflow.md) and [ADR-0006](docs/adr/0006-product-docs-and-prd-workflow.md) for the reasoning behind this workflow.
 
 ## Getting Started
 
@@ -223,6 +224,7 @@ test(api): add unit tests for reminder service
 - **.NET**: Follow Microsoft's C# coding conventions
 - **TypeScript/React**: Follow the existing ESLint configuration
 - **Solidity**: Follow Solidity style guide
+- **UI**: changes follow the [design system](docs/design/reminders-redesign/design-system.md)
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -184,4 +184,4 @@ If you encounter any issues or have suggestions, we encourage you to open an iss
 
 ## Project Planning
 
-Work is planned and tracked on the [Reminders project board](https://github.com/users/jumperck/projects/7). Progress updates follow GitHub's [sharing project updates](https://docs.github.com/en/issues/planning-and-tracking-with-projects/sharing-project-updates) guide.
+Work is planned and tracked on the [Reminders project board](https://github.com/users/jumperck/projects/7). Progress updates follow GitHub's [sharing project updates](https://docs.github.com/en/issues/planning-and-tracking-with-projects/sharing-project-updates) guide. Product direction and PRDs live in [docs/product/](docs/product/README.md).

--- a/docs/adr/0006-product-docs-and-prd-workflow.md
+++ b/docs/adr/0006-product-docs-and-prd-workflow.md
@@ -1,0 +1,31 @@
+# ADR-0006: Product docs and PRD workflow
+
+- **Status**: accepted
+- **Date**: 2026-07-28
+- **Issue**: #367
+
+## Context
+
+The workflow records technical decisions (ADRs) and execution state (issues, project board), but nothing records product intent or outcomes. Ideas discussions (#363, #364, #365, #366) hold feature-sized directions with no defined path from idea to shipped, validated work. Feature issues state acceptance criteria but not the user problem or how success is measured after release.
+
+## Options considered
+
+### Option 1: Discussions and issues only
+
+Keep product intent in discussions and issue bodies. Buys zero new artifacts; costs intent scattered across threads, no record of whether shipped features achieved anything.
+
+### Option 2: Full product documentation
+
+Roadmap, personas, OKRs, specs. Buys thoroughness; costs heavy upkeep for a solo project and duplicates what the board already does.
+
+### Option 3: Lean PRDs mirroring the ADR pattern
+
+One-page PRDs in `docs/product/` with template, index, and lifecycle, plus a one-page vision. Buys traceability from idea to validated outcome at minimal cost.
+
+## Decision
+
+Option 3. The flow for feature-sized work: Ideas discussion, then a PRD (problem, users, success criteria, scope, non-goals), then ADRs for technical decisions made while building, then issues, PRs, and release, with validation evidence recorded back in the PRD. PRD lifecycle: draft, active, shipped, validated. Small fixes and chores skip the PRD.
+
+## Consequences
+
+Features gain one extra artifact, so starting them costs slightly more. Product intent and outcomes become reviewable in the repo instead of living in threads. The Validation section forces a post-release check against the stated success criteria. Vision stays a compass: the board and discussions remain the roadmap.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,6 +11,7 @@ Decisions that shape architecture, workflow, or tooling are recorded here so hum
 | [0003](0003-multi-implementation-api.md) | Same REST API in .NET, Go and C++ behind Nginx | accepted | 2026-07-28 |
 | [0004](0004-dual-database-migrations-runner.md) | Dual database providers with a dedicated migrations runner | accepted | 2026-07-28 |
 | [0005](0005-blockchain-integration.md) | Solidity contracts with a local Ganache node in the stack | accepted | 2026-07-28 |
+| [0006](0006-product-docs-and-prd-workflow.md) | Product docs and PRD workflow | accepted | 2026-07-28 |
 
 ## Process
 

--- a/docs/product/0000-template.md
+++ b/docs/product/0000-template.md
@@ -1,0 +1,35 @@
+# PRD-NNNN: Title
+
+- **Status**: draft | active | shipped | validated
+- **Date**: YYYY-MM-DD
+- **Discussion**: link to the Ideas discussion that spawned this
+
+## Problem
+
+What hurts today and for whom. Facts, not solutions.
+
+## Users
+
+Who benefits and how they use it.
+
+## Success criteria
+
+2-4 measurable bullets. How we know this worked, not what we will build.
+
+## Scope
+
+What ships. Keep it to the smallest useful slice. UI-touching work follows [the design system](../design/reminders-redesign/design-system.md).
+
+## Non-goals
+
+What this deliberately does not cover, and why.
+
+## Links
+
+- Parent issue: #NNN
+- ADRs: ADR-NNNN (added as decisions are made)
+- Release: vX.Y.Z (added at ship)
+
+## Validation
+
+Empty until shipped. After release, record what the success criteria showed: numbers, screenshots, or a short verdict.

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -1,0 +1,19 @@
+# Product Docs
+
+Product intent and outcomes are recorded here so features trace from idea to validated result. Direction lives in [vision.md](vision.md). Each feature-sized effort gets a one-page PRD following [0000-template.md](0000-template.md): problem, users, success criteria, scope, non-goals, validation.
+
+## Index
+
+| PRD | Title | Status | Date |
+|---|---|---|---|
+
+## Process
+
+1. Direction starts as an Ideas discussion.
+2. Draft the PRD as `NNNN-short-title.md` with status `draft`, in a PR.
+3. Merge when scope is agreed: status becomes `active`; open the parent feature issue linking the PRD.
+4. Technical decisions made during implementation land as ADRs referencing the PRD.
+5. At release: status becomes `shipped`. Fill the Validation section with evidence: status becomes `validated`.
+6. Add every new PRD to the index table above in the same PR.
+
+Small fixes and chores do not need a PRD.

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -1,0 +1,23 @@
+# Product Vision
+
+Reminders is a task-reminder product built as the same application across multiple stacks: three API implementations (.NET, Go, C++) behind one contract, two web frontends, a mobile app, and a blockchain audit trail. It is for people who want a simple, fast way to capture reminders and trust that they resurface at the right time. The multi-stack setup keeps every feature honest: if it cannot be expressed in the shared REST contract, it is not ready.
+
+The board and the Ideas discussions are the roadmap. This page only sets direction.
+
+## Pillars
+
+### Reliable delivery
+
+Reminders should fire, not just sit in a list. Scheduled delivery over email, push, or webhook, with retries, dead-letter handling, and idempotent processing. See [discussion #363](https://github.com/jumperck/Reminders/discussions/363).
+
+### Assistive intelligence
+
+Capturing a reminder should take one natural sentence, and the app should help triage what is overdue. Natural language parsing, semantic search, and evaluated LLM features. See [discussion #364](https://github.com/jumperck/Reminders/discussions/364).
+
+### Event-driven core
+
+Domain events give the polyglot services a real role: consumers in Go and C++, history and audit views built from the event stream. See [discussion #365](https://github.com/jumperck/Reminders/discussions/365).
+
+### Explorations
+
+Smaller ideas that sharpen the product without a pillar of their own: authentication, rate limiting, health checks. See [discussion #366](https://github.com/jumperck/Reminders/discussions/366).


### PR DESCRIPTION
## What changes

Adds a lean product docs layer mirroring the ADR pattern. Closes #367

- `docs/product/`: one-page vision (pillars linked to Ideas discussions #363-#366), PRD template, index with lifecycle (draft, active, shipped, validated)
- ADR-0006: records the flow Discussion, then PRD, then ADRs during implementation, then issues, PRs, release, with validation evidence recorded back in the PRD
- CONTRIBUTING: PRD step in the change workflow for feature-sized work; small fixes stay lightweight; UI changes point at the design system
- Feature issue form and PR template reference PRDs; CLAUDE.md gains agent rules; README links docs/product/

## Why

ADRs record technical decisions and issues track execution, but nothing captured product intent or whether shipped features achieved their goal.

## Related PRD / ADR

docs/adr/0006-product-docs-and-prd-workflow.md

## How to test

Docs only. Read docs/product/README.md and follow links; issue form YAML validated locally.

## Checklist

- [x] Relevant test suite passes locally (docs only, no code)
- [x] Docs updated where needed (README, CONTRIBUTING, agents.md, ADR index)
- [x] Migrations added for both Postgres and SqlServer, or no schema change
- [x] Breaking changes flagged with `!` and a `BREAKING CHANGE:` footer, or none