### PR TITLE
fix(api): add retry and graceful degradation for blockchain calls

### DIFF
--- a/src/server/api/dotnet/Reminders.Api/Layers/Application/Services/RemindersBlockchainService.cs
+++ b/src/server/api/dotnet/Reminders.Api/Layers/Application/Services/RemindersBlockchainService.cs
@@ -3,6 +3,7 @@ using Nethereum.Web3;
 using Nethereum.Web3.Accounts;
 using Nethereum.Contracts;
 using Nethereum.Hex.HexTypes;
+using Polly.CircuitBreaker;
 using System.Text.Json.Serialization;
 using System.Text.Json;
 
@@ -63,13 +64,40 @@ public class ReminderContractFunctions
 
 public class RemindersBlockchainService : IRemindersBlockchainService
 {
+    // Shared across scoped instances so failures accumulate into one circuit.
+    private static readonly AsyncCircuitBreakerPolicy CircuitBreaker =
+        Policy
+            .Handle<Exception>()
+            .CircuitBreakerAsync(
+                exceptionsAllowedBeforeBreaking: 3,
+                durationOfBreak: TimeSpan.FromSeconds(30));
+
+    private readonly AsyncPolicy resiliencePolicy;
+    private readonly ILogger<RemindersBlockchainService> logger;
     private readonly BlockchainSettings settings;
     private readonly Web3 web3;
     private readonly Contract contract;
 
-    public RemindersBlockchainService(IOptions<BlockchainSettings> settings)
+    public RemindersBlockchainService(
+        ILogger<RemindersBlockchainService> logger,
+        IOptions<BlockchainSettings> settings)
     {
+        this.logger = logger;
         this.settings = settings.Value;
+
+        var retry = Policy
+            .Handle<Exception>(exception => exception is not BrokenCircuitException)
+            .WaitAndRetryAsync(
+                retryCount: 3,
+                sleepDurationProvider: attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt - 1)),
+                onRetry: (exception, delay, attempt, _) =>
+                    this.logger.LogWarning(
+                        exception,
+                        "Blockchain call failed (attempt {Attempt}), retrying in {Delay}s",
+                        attempt,
+                        delay.TotalSeconds));
+
+        resiliencePolicy = retry.WrapAsync(CircuitBreaker);
 
         web3 = new Web3(new Account(this.settings.PrivateKey), this.settings.NodeUrl);
         var abiJson = System.Text.Json.JsonSerializer.Serialize(this.settings.Abi, new JsonSerializerOptions
@@ -85,13 +113,14 @@ public class RemindersBlockchainService : IRemindersBlockchainService
     {
         var createFunction = this.contract.GetFunction(ReminderContractFunctions.Create);
 
-        var receipt = await createFunction.SendTransactionAndWaitForReceiptAsync(
-            this.web3.TransactionManager.Account.Address,
-            new HexBigInteger(300000),
-            null,
-            null,
-            text
-        );
+        var receipt = await resiliencePolicy.ExecuteAsync(() =>
+            createFunction.SendTransactionAndWaitForReceiptAsync(
+                this.web3.TransactionManager.Account.Address,
+                new HexBigInteger(300000),
+                null,
+                null,
+                text
+            ));
 
         return receipt.TransactionHash;
     }
@@ -105,7 +134,8 @@ public class RemindersBlockchainService : IRemindersBlockchainService
 
         var getFunction = this.contract.GetFunction(ReminderContractFunctions.Get);
 
-        var result = await getFunction.CallDeserializingToObjectAsync<GetReminderOutput>(id);
+        var result = await resiliencePolicy.ExecuteAsync(() =>
+            getFunction.CallDeserializingToObjectAsync<GetReminderOutput>(id));
 
         return result;
     }
@@ -114,7 +144,7 @@ public class RemindersBlockchainService : IRemindersBlockchainService
     {
         var countFunction = this.contract.GetFunction(ReminderContractFunctions.Count); // Add this to your Solidity contract
 
-        var count = await countFunction.CallAsync<int>();
+        var count = await resiliencePolicy.ExecuteAsync(() => countFunction.CallAsync<int>());
 
         return count;
     }
@@ -123,13 +153,14 @@ public class RemindersBlockchainService : IRemindersBlockchainService
     {
         var deleteFunction = this.contract.GetFunction(ReminderContractFunctions.Delete);
 
-        var receipt = await deleteFunction.SendTransactionAndWaitForReceiptAsync(
-            this.web3.TransactionManager.Account.Address,
-            new HexBigInteger(300000),
-            null,
-            null,
-            id
-        );
+        var receipt = await resiliencePolicy.ExecuteAsync(() =>
+            deleteFunction.SendTransactionAndWaitForReceiptAsync(
+                this.web3.TransactionManager.Account.Address,
+                new HexBigInteger(300000),
+                null,
+                null,
+                id
+            ));
 
         return receipt.TransactionHash;
     }
@@ -138,14 +169,15 @@ public class RemindersBlockchainService : IRemindersBlockchainService
     {
         var updateFunction = this.contract.GetFunction(ReminderContractFunctions.Update);
 
-        var receipt = await updateFunction.SendTransactionAndWaitForReceiptAsync(
-            this.web3.TransactionManager.Account.Address,
-            new HexBigInteger(300000),
-            null,
-            null,
-            id,
-            text
-        );
+        var receipt = await resiliencePolicy.ExecuteAsync(() =>
+            updateFunction.SendTransactionAndWaitForReceiptAsync(
+                this.web3.TransactionManager.Account.Address,
+                new HexBigInteger(300000),
+                null,
+                null,
+                id,
+                text
+            ));
 
         return receipt.TransactionHash;
     }

--- a/src/server/api/dotnet/Reminders.Api/Layers/Application/Services/RemindersService.cs
+++ b/src/server/api/dotnet/Reminders.Api/Layers/Application/Services/RemindersService.cs
@@ -44,11 +44,18 @@ public class RemindersService
 
         if (reminder.Title is not null)
         {
-            var chainId = 0; // TODO: This will need to stored in a separated way.
-            var transactionHash = await remindersBlockchainService.CreateReminderAsync(reminder.Title);
-            var output = await remindersBlockchainService.GetReminderAsync(chainId);
+            try
+            {
+                var chainId = 0; // TODO: This will need to stored in a separated way.
+                var transactionHash = await remindersBlockchainService.CreateReminderAsync(reminder.Title);
+                var output = await remindersBlockchainService.GetReminderAsync(chainId);
 
-            this.logger.LogInformation($"Blockchain: {output.Text} - {output.Owner} - {transactionHash}");
+                this.logger.LogInformation($"Blockchain: {output.Text} - {output.Owner} - {transactionHash}");
+            }
+            catch (Exception exception)
+            {
+                this.logger.LogError(exception, "Blockchain create failed, reminder saved to database only");
+            }
         }
 
         unitOfWork.Commit();
@@ -75,11 +82,18 @@ public class RemindersService
 
         if (reminder.Title is not null)
         {
-            var chainId = 0; // TODO: This will need to stored in a separated way.
-            var transactionHash = await remindersBlockchainService.UpdateReminderAsync(chainId, reminder.Title);
-            var output = await remindersBlockchainService.GetReminderAsync(chainId);
+            try
+            {
+                var chainId = 0; // TODO: This will need to stored in a separated way.
+                var transactionHash = await remindersBlockchainService.UpdateReminderAsync(chainId, reminder.Title);
+                var output = await remindersBlockchainService.GetReminderAsync(chainId);
 
-            this.logger.LogInformation($"Blockchain: {output.Text} - {output.Owner} - {transactionHash}");
+                this.logger.LogInformation($"Blockchain: {output.Text} - {output.Owner} - {transactionHash}");
+            }
+            catch (Exception exception)
+            {
+                this.logger.LogError(exception, "Blockchain update failed, reminder saved to database only");
+            }
         }
 
         unitOfWork.Commit();
@@ -98,11 +112,18 @@ public class RemindersService
         {
             reminderData.Delete();
 
-            var chainId = 0; // TODO: This will need to stored in a separated way.
-            var output = await remindersBlockchainService.GetReminderAsync(chainId);
-            await remindersBlockchainService.DeleteReminderAsync(chainId);
+            try
+            {
+                var chainId = 0; // TODO: This will need to stored in a separated way.
+                var output = await remindersBlockchainService.GetReminderAsync(chainId);
+                await remindersBlockchainService.DeleteReminderAsync(chainId);
 
-            this.logger.LogInformation($"Blockchain: {output.Text} - {output.Owner}");
+                this.logger.LogInformation($"Blockchain: {output.Text} - {output.Owner}");
+            }
+            catch (Exception exception)
+            {
+                this.logger.LogError(exception, "Blockchain delete failed, reminder deleted from database only");
+            }
 
             remindersRepository.Update(reminderData);
 
@@ -132,10 +153,17 @@ public class RemindersService
             .Get()
             .FirstOrDefault(reminder => reminder.Id == id && !reminder.IsDeleted);
 
-        var chainId = 0; // TODO: This will need to stored in a separated way.
-        var output = await remindersBlockchainService.GetReminderAsync(chainId);
+        try
+        {
+            var chainId = 0; // TODO: This will need to stored in a separated way.
+            var output = await remindersBlockchainService.GetReminderAsync(chainId);
 
-        this.logger.LogInformation($"Blockchain: {output.Text} - {output.Owner}");
+            this.logger.LogInformation($"Blockchain: {output.Text} - {output.Owner}");
+        }
+        catch (Exception exception)
+        {
+            this.logger.LogError(exception, "Blockchain read failed, returning database data only");
+        }
 
         var reminderViewModel = mapper.Map<ReminderViewModel>(reminder);
 

--- a/src/test/server/dotnet/Reminders.Application.Test/Reminders/ReminderServiceUnitTest.cs
+++ b/src/test/server/dotnet/Reminders.Application.Test/Reminders/ReminderServiceUnitTest.cs
@@ -442,6 +442,125 @@ namespace Reminders.Application.Test
 
         #endregion
 
+        #region Blockchain degradation
+
+        [Timeout(1000)]
+        [TestMethod]
+        public async Task Should_InsertWhenBlockchainFails()
+        {
+            // arrange
+            remindersBlockchainService
+                .Setup(x => x.CreateReminderAsync(It.IsAny<string>()))
+                .ThrowsAsync(new Exception("node down"));
+
+            var reminder = new ReminderViewModel()
+            {
+                Title = "Title",
+                Description = "Description",
+                LimitDate = DateTime.UtcNow.AddDays(1)
+            };
+
+            // act
+            var service = GetRemindersService();
+
+            var result = await service.InsertAsync(reminder);
+
+            // assert
+            Assert.IsNotNull(result);
+            repositoryMock.Verify(repository => repository.Add(It.IsAny<Reminder>()), Times.Once);
+            unitOfWorkMock.Verify(unitOfWork => unitOfWork.Commit(), Times.Once);
+        }
+
+        [Timeout(1000)]
+        [TestMethod]
+        public async Task Should_EditWhenBlockchainFails()
+        {
+            // arrange
+            remindersBlockchainService
+                .Setup(x => x.UpdateReminderAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ThrowsAsync(new Exception("node down"));
+
+            var reminder = new ReminderViewModel()
+            {
+                Id = Guid.NewGuid(),
+                Title = "Title",
+                Description = "Description",
+                LimitDate = DateTime.UtcNow.AddDays(1)
+            };
+
+            repositoryMock
+                .Setup(repository => repository.Exists(It.IsAny<Guid>()))
+                .Returns(true);
+
+            // act
+            var service = GetRemindersService();
+
+            await service.EditAsync(reminder.Id.Value, reminder);
+
+            // assert
+            repositoryMock.Verify(repository => repository.Update(It.IsAny<Reminder>()), Times.Once);
+            unitOfWorkMock.Verify(unitOfWork => unitOfWork.Commit(), Times.Once);
+        }
+
+        [Timeout(1000)]
+        [TestMethod]
+        public async Task Should_DeleteWhenBlockchainFails()
+        {
+            // arrange
+            remindersBlockchainService
+                .Setup(x => x.GetReminderAsync(It.IsAny<int>()))
+                .ThrowsAsync(new Exception("node down"));
+
+            var reminder = new Reminder("My Title", "My Description", DateTime.UtcNow, false);
+
+            repositoryMock
+                .Setup(repository => repository.Exists(It.IsAny<Guid>()))
+                .Returns(true);
+
+            repositoryMock
+                .Setup(repository => repository.Get(It.IsAny<Guid>()))
+                .Returns(reminder);
+
+            // act
+            var service = GetRemindersService();
+
+            await service.DeleteAsync(reminder.Id);
+
+            // assert
+            repositoryMock.Verify(repository =>
+                repository.Update(It.Is<Reminder>(r => r.IsDeleted)), Times.Once);
+            unitOfWorkMock.Verify(unitOfWork => unitOfWork.Commit(), Times.Once);
+        }
+
+        [Timeout(1000)]
+        [TestMethod]
+        public async Task Should_GetByIdWhenBlockchainFails()
+        {
+            // arrange
+            remindersBlockchainService
+                .Setup(x => x.GetReminderAsync(It.IsAny<int>()))
+                .ThrowsAsync(new Exception("node down"));
+
+            var reminder = new Reminder("My Title", "My Description", DateTime.UtcNow, false);
+
+            repositoryMock
+                .Setup(repository => repository.Get())
+                .Returns(new List<Reminder>
+                {
+                    reminder
+                }.AsQueryable());
+
+            var service = GetRemindersService();
+
+            // act
+            var result = await service.GetAsync(reminder.Id);
+
+            // assert
+            Assert.AreEqual(reminder.Title, result.Title);
+        }
+
+        #endregion
+
         #region Instance
 
         [Timeout(1000)]


### PR DESCRIPTION
## Summary
- Wrap all Nethereum calls in `RemindersBlockchainService` with Polly: retry (3 attempts, exponential backoff 1/2/4s, logged warnings) around a static circuit breaker (opens after 3 consecutive failures, 30s break, shared across scoped instances). Retry skips `BrokenCircuitException` so an open circuit fails fast.
- `RemindersService` catches blockchain failures on Insert/Edit/Delete/GetAsync, logs an error, and continues: reminders are saved to the database even when the chain write fails. Ganache down no longer crashes the API.
- 4 new unit tests assert DB add/update/commit still happen when the blockchain service throws. 51/51 passing.

Closes #300

## Test plan
- [x] `dotnet test src/test/server/dotnet/Reminders.Application.Test/` (51 passed)
- [ ] Manual smoke: `docker compose --profile api up -d`, stop ganache, POST a reminder, expect 200 + retry warnings in API logs
- [ ] Chaos-style e2e (stop Ganache mid-suite) deferred to #305