### PR TITLE
docs: fix skill YAML frontmatter and make it portable

### DIFF
--- a/.claude/skills/github-workflow/SKILL.md
+++ b/.claude/skills/github-workflow/SKILL.md
@@ -7,11 +7,20 @@ description: "Manage the jumperck/Reminders backlog on GitHub: issues, labels, P
 
 Repo: `jumperck/Reminders`. Backlog lives in GitHub Issues, execution view is Project 7. Views: [board](https://github.com/users/jumperck/projects/7) (columns) and [roadmap](https://github.com/users/jumperck/projects/7/views/2) (timeline by sprint; link this when pointing people at the plan). Rules below complement CLAUDE.md (label taxonomy, sprint ritual, commit conventions); this skill holds the command recipes.
 
-## Environment notes
+## Ground rules
 
-- `jq` is NOT installed. Use `gh --jq` (built-in) instead of piping to jq.
+- Use gh's built-in `--jq` flag for JSON filtering; do not assume `jq` is installed on the machine.
 - Never add AI attribution to commits, PRs, or comments.
 - No em/en dashes anywhere.
+- Never merge a PR yourself: open it, share the URL, wait for the maintainer's review and approval.
+
+## Finding something to work on
+
+1. `gh issue list --limit 50` for the open backlog.
+2. Query the current sprint (see Sprints below) and pick from its unassigned Todo items, highest priority first (P0 > P1 > P2).
+3. No sprint items left: pick an unassigned Todo item from the board. Backlog-status items are not yet prioritized; propose before starting.
+4. Skip issues that are assigned, or labeled `hold`/`triage`. Parent `feature` issues track plans; work their child `task` issues.
+5. Claim it: assign yourself + move the board item to In Progress (no comment), then branch off main.
 
 ## Stable IDs (Project 7)
 

--- a/.claude/skills/github-workflow/SKILL.md
+++ b/.claude/skills/github-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-workflow
-description: Manage the jumperck/Reminders backlog on GitHub: issues, labels, Project 7 board (status, priority, sprints), discussions, and PRs. Use when claiming work, triaging, running the sprint check-in ritual, or opening/merging PRs.
+description: "Manage the jumperck/Reminders backlog on GitHub: issues, labels, Project 7 board (status, priority, sprints), discussions, and PRs. Use when claiming work, triaging, running the sprint check-in ritual, or opening/merging PRs."
 ---
 
 # GitHub workflow for jumperck/Reminders

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,7 @@ Never use em dash (—) or en dash (–) anywhere: docs, comments, commit messag
 - Read `agents.md` for architecture patterns before editing service code.
 - Database changes require migrations for **both** Postgres and SqlServer providers (see agents.md).
 - Do not commit, push, tag, or open PRs unless explicitly asked.
+- Never merge a PR without explicit human approval of that specific PR, given as a PR review/approval or in chat. After opening a PR, share the URL and wait.
 - No AI attribution anywhere: no Co-Authored-By trailers, session links, or "Generated with" footers in commits, PR bodies, or comments. Commit author is the maintainer.
 - Agent branches follow the repo convention `<type>/<short-description>` (e.g. `chore/repo-governance`), never `claude/...` or any other auto-generated prefix. If the session assigns a `claude/...` branch, recreate the work on a convention-named branch before opening a PR.
 - Run the relevant test suite after code changes.


### PR DESCRIPTION
## Summary
- Fix invalid YAML frontmatter in the github-workflow skill: unquoted colon in `description` broke parsing ("mapping values are not allowed in this context").
- Generalize the skill for any machine/user: portable `--jq` guidance instead of personal-machine notes, new "finding something to work on" flow (sprint first, priority order, claim ritual), and an explicit rule that agents never merge PRs themselves.
- CLAUDE.md: new rule, never merge a PR without explicit human approval (PR review or chat); opening a PR ends with sharing the URL and waiting.

## Test plan
- [x] Frontmatter parses (skill loads without YAML error)
- [ ] Maintainer review of skill and CLAUDE.md rule