### PR TITLE
refactor(api): externalize chainId and contract address to config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ BLOCKCHAIN_PRIVATE_KEY=0xc87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a
 # Smart contract address (deploy contract first to get this address)
 BLOCKCHAIN_CONTRACT_ADDRESS=0xf204a4Ef082f5c04bB89F7D5E6568B796096735a
 
+# On-chain reminder id used by the API (single-reminder contract slot for now)
+BLOCKCHAIN_CHAIN_ID=0
+
 # =============================================================================
 # API Configuration
 # =============================================================================

--- a/blockchain/scripts/count.js
+++ b/blockchain/scripts/count.js
@@ -1,8 +1,7 @@
 const { ethers } = require("hardhat");
 
 async function main() {
-    // Get contract address from environment variable or command line argument
-    const contractAddress = '0xbaAA2a3237035A2c7fA2A33c76B44a8C6Fe18e87';
+    const contractAddress = process.env.BLOCKCHAIN_CONTRACT_ADDRESS || '0xf204a4Ef082f5c04bB89F7D5E6568B796096735a';
     const reminder = 'test-reminder';
 
     const Reminders = await ethers.getContractFactory("Reminders");

--- a/blockchain/scripts/create.js
+++ b/blockchain/scripts/create.js
@@ -1,8 +1,7 @@
 const { ethers } = require("hardhat");
 
 async function main() {
-    // Get contract address from environment variable or command line argument
-    const contractAddress = '0xbaAA2a3237035A2c7fA2A33c76B44a8C6Fe18e87';
+    const contractAddress = process.env.BLOCKCHAIN_CONTRACT_ADDRESS || '0xf204a4Ef082f5c04bB89F7D5E6568B796096735a';
     const reminder = 'test-reminder';
 
     const Reminders = await ethers.getContractFactory("Reminders");

--- a/blockchain/scripts/get.js
+++ b/blockchain/scripts/get.js
@@ -1,8 +1,7 @@
 const { ethers } = require("hardhat");
 
 async function main() {
-    // Get contract address from command line argument
-    const contractAddress = '0x38cF23C52Bb4B13F051Aec09580a2dE845a7FA35';
+    const contractAddress = process.env.BLOCKCHAIN_CONTRACT_ADDRESS || '0xf204a4Ef082f5c04bB89F7D5E6568B796096735a';
 
     const Reminders = await ethers.getContractFactory("Reminders");
     const reminders = Reminders.attach(contractAddress);

--- a/blockchain/scripts/monitor.js
+++ b/blockchain/scripts/monitor.js
@@ -1,5 +1,5 @@
 async function monitor() {
-  const contractAddress = "0xbaAA2a3237035A2c7fA2A33c76B44a8C6Fe18e87";
+  const contractAddress = process.env.BLOCKCHAIN_CONTRACT_ADDRESS || "0xf204a4Ef082f5c04bB89F7D5E6568B796096735a";
   const Reminders = await ethers.getContractFactory("Reminders");
   const reminders = await Reminders.attach(contractAddress);
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -47,9 +47,10 @@ services:
       ConnectionStrings__DefaultConnection: Host=reminders-postgres;Database=Reminders;Username=root;Password=h9pJwUUV0y;Pooling=true;
       DatabaseProvider: Postgres
 
-      Blockchain__PrivateKey: 0xc87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3
-      Blockchain__NodeUrl: http://reminders-blockchain:8545
-      Blockchain__ContractAddress: 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a
+      Blockchain__PrivateKey: ${BLOCKCHAIN_PRIVATE_KEY:-0xc87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3}
+      Blockchain__NodeUrl: ${BLOCKCHAIN_NODE_URL:-http://reminders-blockchain:8545}
+      Blockchain__ContractAddress: ${BLOCKCHAIN_CONTRACT_ADDRESS:-0xf204a4Ef082f5c04bB89F7D5E6568B796096735a}
+      Blockchain__ChainId: ${BLOCKCHAIN_CHAIN_ID:-0}
     volumes: &dotnet-volumes
       - type: bind
         source: ${HOME}/.microsoft/usersecrets

--- a/src/server/api/dotnet/Reminders.Api/Layers/Application/Services/RemindersBlockchainService.cs
+++ b/src/server/api/dotnet/Reminders.Api/Layers/Application/Services/RemindersBlockchainService.cs
@@ -14,6 +14,7 @@ public class BlockchainSettings
     public string PrivateKey { get; set; } = string.Empty;
     public string NodeUrl { get; set; } = string.Empty;
     public string ContractAddress { get; set; } = string.Empty;
+    public int ChainId { get; set; }
     public List<AbiItem> Abi { get; set; } = new();
 }
 

--- a/src/server/api/dotnet/Reminders.Api/Layers/Application/Services/RemindersService.cs
+++ b/src/server/api/dotnet/Reminders.Api/Layers/Application/Services/RemindersService.cs
@@ -1,4 +1,6 @@
-﻿namespace Reminders.Application.Services;
+﻿using Microsoft.Extensions.Options;
+
+namespace Reminders.Application.Services;
 
 public class RemindersService
   : IRemindersService
@@ -9,13 +11,15 @@ public class RemindersService
     private readonly IRemindersRepository remindersRepository;
     private readonly IRemindersBlockchainService remindersBlockchainService;
     private readonly IUnitOfWork unitOfWork;
+    private readonly BlockchainSettings blockchainSettings;
 
     public RemindersService(
         ILogger<RemindersService> logger,
         IMapper mapper,
         IRemindersRepository remindersRepository,
         IRemindersBlockchainService remindersBlockchainService,
-        IUnitOfWork unitOfWork)
+        IUnitOfWork unitOfWork,
+        IOptions<BlockchainSettings> blockchainSettings)
     {
         validator = new ReminderViewModelValidator();
 
@@ -24,6 +28,7 @@ public class RemindersService
         this.remindersRepository = remindersRepository;
         this.remindersBlockchainService = remindersBlockchainService;
         this.unitOfWork = unitOfWork;
+        this.blockchainSettings = blockchainSettings.Value;
     }
 
     public async Task<ReminderViewModel> InsertAsync(ReminderViewModel reminderViewModel)
@@ -46,7 +51,7 @@ public class RemindersService
         {
             try
             {
-                var chainId = 0; // TODO: This will need to stored in a separated way.
+                var chainId = blockchainSettings.ChainId;
                 var transactionHash = await remindersBlockchainService.CreateReminderAsync(reminder.Title);
                 var output = await remindersBlockchainService.GetReminderAsync(chainId);
 
@@ -84,7 +89,7 @@ public class RemindersService
         {
             try
             {
-                var chainId = 0; // TODO: This will need to stored in a separated way.
+                var chainId = blockchainSettings.ChainId;
                 var transactionHash = await remindersBlockchainService.UpdateReminderAsync(chainId, reminder.Title);
                 var output = await remindersBlockchainService.GetReminderAsync(chainId);
 
@@ -114,7 +119,7 @@ public class RemindersService
 
             try
             {
-                var chainId = 0; // TODO: This will need to stored in a separated way.
+                var chainId = blockchainSettings.ChainId;
                 var output = await remindersBlockchainService.GetReminderAsync(chainId);
                 await remindersBlockchainService.DeleteReminderAsync(chainId);
 
@@ -155,7 +160,7 @@ public class RemindersService
 
         try
         {
-            var chainId = 0; // TODO: This will need to stored in a separated way.
+            var chainId = blockchainSettings.ChainId;
             var output = await remindersBlockchainService.GetReminderAsync(chainId);
 
             this.logger.LogInformation($"Blockchain: {output.Text} - {output.Owner}");

--- a/src/server/api/dotnet/Reminders.Api/appsettings.Development.json
+++ b/src/server/api/dotnet/Reminders.Api/appsettings.Development.json
@@ -19,6 +19,7 @@
     "PrivateKey": "0xc87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3",
     "NodeUrl": "http://reminders-blockchain:8545",
     "ContractAddress": "0xf204a4Ef082f5c04bB89F7D5E6568B796096735a",
+    "ChainId": 0,
     "Abi": [
       {
         "anonymous": false,

--- a/src/server/api/dotnet/Reminders.Api/appsettings.json
+++ b/src/server/api/dotnet/Reminders.Api/appsettings.json
@@ -16,6 +16,7 @@
 		"PrivateKey": "",
 		"NodeUrl": "",
 		"ContractAddress": "",
+		"ChainId": 0,
 		"AbiPath": []
 	}
 }

--- a/src/test/server/dotnet/Reminders.Application.Test/Reminders/ReminderServiceUnitTest.cs
+++ b/src/test/server/dotnet/Reminders.Application.Test/Reminders/ReminderServiceUnitTest.cs
@@ -87,7 +87,8 @@ namespace Reminders.Application.Test
                 mapperMock,
                 repositoryMock.Object,
                 remindersBlockchainService.Object,
-                unitOfWorkMock.Object);
+                unitOfWorkMock.Object,
+                Microsoft.Extensions.Options.Options.Create(new BlockchainSettings()));
 
         #endregion
 


### PR DESCRIPTION
## Summary
- Add `Blockchain.ChainId` setting; `RemindersService` now reads the on-chain reminder id from `IOptions<BlockchainSettings>` instead of four hardcoded `var chainId = 0; // TODO` occurrences
- Compose passes `Blockchain__ChainId` and interpolates all blockchain env vars as `${VAR:-default}` so `.env` is the single source of truth; `.env.example` documents `BLOCKCHAIN_CHAIN_ID`
- Hardhat scripts (`create`, `count`, `get`, `monitor`) read `BLOCKCHAIN_CONTRACT_ADDRESS` from env, replacing three divergent stale hardcoded addresses

Note: `ChainId` is the single-reminder contract slot index, not a network id. Proper per-reminder mapping is out of scope here.

Closes #301

## Test plan
- [x] `dotnet test` 51/51 passed
- [x] `docker compose config -q` ok