### PR TITLE
docs: require runtime smoke test for infra changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,4 +177,5 @@ Never use em dash (—) or en dash (–) anywhere: docs, comments, commit messag
 - No AI attribution anywhere: no Co-Authored-By trailers, session links, or "Generated with" footers in commits, PR bodies, or comments. Commit author is the maintainer.
 - Agent branches follow the repo convention `<type>/<short-description>` (e.g. `chore/repo-governance`), never `claude/...` or any other auto-generated prefix. If the session assigns a `claude/...` branch, recreate the work on a convention-named branch before opening a PR.
 - Run the relevant test suite after code changes.
+- Changes to compose files, Dockerfiles, or `infrastructure/` require a runtime smoke test before opening the PR: boot the affected profile (`docker compose --profile api up --build -d`), hit an endpoint, then tear down. `docker compose config -q` alone is not enough.
 - No secrets in code or compose files: use `.env` (gitignored); `.env.example` holds placeholders only.


### PR DESCRIPTION
## Summary
- Add rule to CLAUDE.md: compose/Dockerfile/infrastructure changes need a runtime smoke test (boot profile, hit endpoint, tear down) before opening the PR, not just `docker compose config -q`

Retro lesson from PR #376: syntax check passed but nothing proved the stack still ran until asked.

## Test plan
- [x] Docs-only change; no code checks apply