### PR TITLE
feat(react): design tokens and fonts foundation

### DIFF
--- a/src/app/reactjs/reminders-app/src/app/globals.css
+++ b/src/app/reactjs/reminders-app/src/app/globals.css
@@ -1,3 +1,46 @@
+:root {
+  /* Color */
+  --canvas: #f3f0e9;
+  --panel: #efebe1;
+  --surface: #fbfaf7;
+  --input-fill: #f7f5f0;
+  --ink: #1b1a17;
+  --body-muted: #6e6759;
+  --faint: #8c8577;
+  --disabled: #9a9385;
+  --border-page: #e0dacd;
+  --border-card: #e7e2d6;
+  --border-input: #ddd7c9;
+  --border-hover: #cfc7b5;
+  --border-hover-strong: #c6bda9;
+  --accent: #b4451f;
+  --accent-hover: #8e3415;
+  --accent-tint: #f6e4dc;
+  --success: #4c6b4f;
+  --success-tint: #edf1ec;
+  --scrim: rgba(27, 26, 23, 0.38);
+  --pill-neutral-bg: #f0ede4;
+
+  /* Type */
+  --font-display: var(--font-instrument-serif), serif;
+  --font-sans: var(--font-dm-sans), system-ui, sans-serif;
+
+  /* Shape */
+  --radius-pill: 999px;
+  --radius-card: 14px;
+  --radius-modal: 18px;
+  --radius-input: 10px;
+  --radius-nav: 10px;
+
+  /* Space */
+  --pad-card: 16px 18px;
+  --pad-modal: 28px;
+  --gutter-page: clamp(20px, 4vw, 48px);
+  --gap-cards: 10px;
+  --gap-sections: 30px;
+  --gap-fields: 18px;
+}
+
 * {
   box-sizing: border-box;
   padding: 0;
@@ -11,13 +54,10 @@ body {
 }
 
 body {
-  color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
+  color: var(--ink);
+  background: var(--canvas);
+  font-family: var(--font-sans);
+  font-size: 15px;
 }
 
 a {

--- a/src/app/reactjs/reminders-app/src/app/layout.tsx
+++ b/src/app/reactjs/reminders-app/src/app/layout.tsx
@@ -1,7 +1,20 @@
 import './globals.css'
 
 import { Suspense } from 'react'
+import { DM_Sans, Instrument_Serif } from 'next/font/google'
 import type { Metadata } from 'next/types'
+
+const instrumentSerif = Instrument_Serif({
+  weight: '400',
+  style: ['normal', 'italic'],
+  subsets: ['latin'],
+  variable: '--font-instrument-serif',
+})
+
+const dmSans = DM_Sans({
+  subsets: ['latin'],
+  variable: '--font-dm-sans',
+})
 
 import { ReminderQueryProvider, RemindersContextProvider } from './hooks'
 
@@ -16,7 +29,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${instrumentSerif.variable} ${dmSans.variable}`}>
       <body suppressHydrationWarning={true}>
         <ReminderQueryProvider>
           {/* Suspense required: RemindersContextProvider reads useSearchParams */}


### PR DESCRIPTION
## Summary
- Add design-system CSS variables to `globals.css`: palette, radii, spacing, font stacks from `docs/design/reminders-redesign/design-system.md`
- Load Instrument Serif + DM Sans via `next/font/google` (self-hosted, exposed as `--font-instrument-serif` / `--font-dm-sans`)
- Base styles: canvas background, ink text, DM Sans 15px body; removed dead gradient variables
- No screen changes yet; screens consume tokens in follow-up issues (#327, #328)

Closes #326

## Test plan
- [x] `next build` passes
- [x] Jest: 70/70 tests pass
- [x] ESLint clean