### PR TITLE
feat(mvc): design tokens stylesheet foundation

### DIFF
--- a/src/app/dotnet/Reminders.Mvc/Views/Shared/_Layout.cshtml
+++ b/src/app/dotnet/Reminders.Mvc/Views/Shared/_Layout.cshtml
@@ -6,6 +6,9 @@
         <title>@ViewData["Title"] - Reminders.Mvc</title>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css"
             integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Instrument+Serif:ital@0;1&display=swap">
         <link rel="stylesheet" href="~/css/site.css" />
     </head>
 

--- a/src/app/dotnet/Reminders.Mvc/wwwroot/css/site.css
+++ b/src/app/dotnet/Reminders.Mvc/wwwroot/css/site.css
@@ -1,3 +1,46 @@
+:root {
+  /* Color */
+  --canvas: #f3f0e9;
+  --panel: #efebe1;
+  --surface: #fbfaf7;
+  --input-fill: #f7f5f0;
+  --ink: #1b1a17;
+  --body-muted: #6e6759;
+  --faint: #8c8577;
+  --disabled: #9a9385;
+  --border-page: #e0dacd;
+  --border-card: #e7e2d6;
+  --border-input: #ddd7c9;
+  --border-hover: #cfc7b5;
+  --border-hover-strong: #c6bda9;
+  --accent: #b4451f;
+  --accent-hover: #8e3415;
+  --accent-tint: #f6e4dc;
+  --success: #4c6b4f;
+  --success-tint: #edf1ec;
+  --scrim: rgba(27, 26, 23, 0.38);
+  --pill-neutral-bg: #f0ede4;
+
+  /* Type */
+  --font-display: 'Instrument Serif', serif;
+  --font-sans: 'DM Sans', system-ui, sans-serif;
+
+  /* Shape */
+  --radius-pill: 999px;
+  --radius-card: 14px;
+  --radius-modal: 18px;
+  --radius-input: 10px;
+  --radius-nav: 10px;
+
+  /* Space */
+  --pad-card: 16px 18px;
+  --pad-modal: 28px;
+  --gutter-page: clamp(20px, 4vw, 48px);
+  --gap-cards: 10px;
+  --gap-sections: 30px;
+  --gap-fields: 18px;
+}
+
 html {
   font-size: 14px;
 }
@@ -19,4 +62,7 @@ html {
 
 body {
   margin-bottom: 60px;
+  color: var(--ink);
+  background-color: var(--canvas);
+  font-family: var(--font-sans);
 }


### PR DESCRIPTION
## Summary
- Add design-system CSS variables to `site.css`: palette, radii, spacing, font stacks from `docs/design/reminders-redesign/design-system.md`, matching the react token set (#379)
- Load Instrument Serif + DM Sans via Google Fonts link with preconnect in `_Layout.cshtml`
- Base styles: canvas background, ink text, DM Sans body; no screen restyling yet (follow-ups #334, #335)

Closes #333

## Test plan
- [x] `dotnet build` passes
- [ ] `Reminders.Mvc.Test` Selenium suite: fails on WSL regardless of this change (Windows-only driver paths, tracked in #380)