### PR TITLE
docs: document Flutter app across top-level docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ All commits and PR titles follow [Conventional Commits](https://www.conventional
 - `cpp`: C++ API
 - `react`: Next.js app
 - `mvc`: ASP.NET MVC app
+- `flutter`: Flutter app (`src/app/flutter/reminders_app/`)
 - `blockchain`: Solidity/Hardhat
 - `migrations`: MigrationsRunner / EF migrations
 - `infra`: Docker, Nginx, k6
@@ -155,6 +156,9 @@ dotnet test src/test/server/dotnet/Reminders.Application.Test/
 
 # React tests
 cd src/app/reactjs/reminders-app && npm test
+
+# Flutter tests
+cd src/app/flutter/reminders_app && flutter analyze && flutter test
 
 # Blockchain tests
 cd blockchain && npx hardhat test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,7 @@ Reminders/
 ├── src/
 │   ├── app/
 │   │   ├── dotnet/                # ASP.NET MVC application
+│   │   ├── flutter/               # Flutter mobile app (Android)
 │   │   └── reactjs/               # Next.js React application
 │   ├── server/
 │   │   ├── api/
@@ -244,6 +245,10 @@ dotnet test
 # React Unit Tests (all passing ✅)
 cd src/app/reactjs/reminders-app
 npm test
+
+# Flutter Tests
+cd src/app/flutter/reminders_app
+flutter analyze && flutter test
 
 # Cypress E2E Tests
 cd src/test/cypress

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ flowchart LR
     subgraph Clients
         react[React app :3000]
         mvc[MVC app :5050]
+        flutter[Flutter app]
     end
 
     nginx[Nginx load balancer :9999]
@@ -110,6 +111,7 @@ flowchart LR
 
     react --> nginx
     mvc --> nginx
+    flutter -.-> nginx
     nginx --> dotnet
     nginx --> goapi
     nginx --> cpp
@@ -122,7 +124,7 @@ flowchart LR
 
 The migrations runner executes once per deployment and must complete before the APIs start. PostgreSQL is the default provider; SQL Server is supported as an alternative with its own migration set.
 
-A Flutter mobile app ([src/app/flutter/reminders_app](src/app/flutter/reminders_app/)) is in progress and will consume the same REST API; see its README for on-device testing.
+The Flutter mobile app ([src/app/flutter/reminders_app](src/app/flutter/reminders_app/), dashed above) is in progress and will consume the same REST API; see its README for on-device testing.
 
 Architecture and workflow decisions are recorded as ADRs: see the [ADR index](docs/adr/README.md).
 
@@ -166,7 +168,7 @@ Reminders API:
 
 ## Testing
 
-The project has unit tests (React/Jest), smart contract tests (Hardhat), .NET integration tests, and end-to-end tests (Cypress) covering the core reminder workflows. Run `./run-tests.sh` from the repository root for the automated suite, or see [CONTRIBUTING.md](CONTRIBUTING.md#testing) and the [Cypress Testing README](src/test/cypress/README.md) for how to run each suite individually.
+The project has unit tests (React/Jest), Flutter widget tests, smart contract tests (Hardhat), .NET integration tests, and end-to-end tests (Cypress) covering the core reminder workflows. Run `./run-tests.sh` from the repository root for the automated suite, or see [CONTRIBUTING.md](CONTRIBUTING.md#testing) and the [Cypress Testing README](src/test/cypress/README.md) for how to run each suite individually.
 
 Migrations are applied by a dedicated runner service before the APIs start - see [CONTRIBUTING.md](CONTRIBUTING.md#database-migrations) for how that works and how to troubleshoot it.
 

--- a/agents.md
+++ b/agents.md
@@ -8,7 +8,7 @@
 
 A full-stack learning project for managing reminders with multiple client interfaces, load-balanced APIs, and blockchain integration.
 
-**Tech Stack**: .NET 8.0, Go (Gin), C++, Next.js 15, PostgreSQL, Solidity, Docker Compose
+**Tech Stack**: .NET 8.0, Go (Gin), C++, Next.js 15, Flutter, PostgreSQL, Solidity, Docker Compose
 
 ## Quick Start for Agents
 


### PR DESCRIPTION
## Summary
- README: Flutter client in the architecture diagram (dashed, not in compose yet), widget tests in the testing paragraph
- agents.md: Flutter in the tech stack line
- CLAUDE.md: `flutter` commit scope, flutter test command
- CONTRIBUTING.md: Flutter in the structure tree and testing section

Closes #385

## Test plan
- [x] Docs only; mermaid syntax renders (validated block structure against existing diagram)